### PR TITLE
fix(navigation): preserve app root when switching hubs

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to PlayTorrio V3 will be documented in this file.
+
+## [3.0.0-early] — 2026-08-11
+
+### Added
+- Stremio-compatible addon protocol with catalog browsing, search, and metadata enrichment
+- 9 VOD stream scrapers (FlyStream, Videasy, VidSrc, MultiEmbed, VidCore, 4KHDHub, XDownloader, Knaben, TorrentGalaxy)
+- Native libtorrent streaming engine with intelligent file selection and real-time stats
+- 9-source audiobook aggregator with torrent and direct streaming support
+- WeebCentral manga reader with horizontal/vertical modes, zoom, and progress tracking
+- Octave music streaming with library management, playlists, and keyboard shortcuts
+- Subdl subtitle download and extraction with multi-language support
+- Glassmorphism UI system with GPU shader effects and performance fallback toggle
+- Custom route transitions (LiquidRevealRoute, CinematicSlideRoute)
+- Responsive card layout adapting to phone, tablet, and desktop widths
+- macOS-style liquid dock navigation
+- 5-platform support (iOS, macOS, Android, Linux, Windows)
+- Audiobook sleep timer and variable playback speed
+- "More Like This" recommendations via BestSimilar scraper
+- Search relevance scoring with exact-match-first ranking
+- Progressive content loading across all sections

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,68 @@
+# Contributing to PlayTorrio V3
+
+Thanks for your interest in contributing. This document outlines the process.
+
+## Getting Started
+
+1. Fork the repository and clone your fork.
+2. Run `flutter pub get` to install dependencies.
+3. Run `flutter analyze` to verify no existing issues.
+4. Make your changes on a feature branch.
+
+## Adding a New VOD Scraper
+
+PlayTorrio uses a plugin architecture for stream scrapers. To add a new source:
+
+1. Create a new file in `lib/services/scraper/sites/`.
+2. Extend the `StreamScraper` abstract class:
+
+```dart
+import '../stream_scraper.dart';
+import '../../../models/stream/stream_model.dart';
+
+class MyScraper extends StreamScraper {
+  @override
+  String get name => 'MyScraper';
+
+  @override
+  Future<List<StreamSource>> scrape({
+    required String type,
+    required String title,
+    int? year,
+    int? season,
+    int? episode,
+    String? imdbId,
+  }) async {
+    // Implement scraping logic here
+    // Return list of StreamSource objects
+  }
+}
+```
+
+3. Register your scraper in `lib/services/stream/stream_service.dart` inside `_registerScrapers()`.
+4. Add a corresponding JS file in `assets/scrapers/` and an entry in `assets/scrapers/sources.json`.
+
+## Adding a New Subtitle Provider
+
+1. Create a file in `lib/services/subtitles/providers/`.
+2. Implement the `SubtitleProvider` abstract class.
+3. Register in `lib/services/subtitles/subtitle_service.dart`.
+
+## Code Style
+
+- Follow the existing patterns in the codebase (singleton services, static utility classes).
+- Prefer `const` constructors where possible.
+- Use `final` over `var` when a variable is not reassigned.
+- Handle errors gracefully — a single failing scraper should never crash the app.
+- Cache network responses where appropriate using the existing LRU pattern.
+
+## Before Submitting
+
+- Run `flutter analyze` and fix all warnings.
+- Run `flutter test` to verify existing tests pass.
+- If you added a scraper or provider, test it against a known-good title.
+- Do not commit API keys or tokens. Use the `secrets.example.dart` pattern.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the MIT License.

--- a/docs/INTERNAL_ARCHITECTURE.md
+++ b/docs/INTERNAL_ARCHITECTURE.md
@@ -27,6 +27,7 @@ At application startup (`void main()`):
 2. **Native Plugin Registration:** `fvp.registerWith()` registers the hardware-accelerated video decoding engine.
 3. **Core Asynchronous Services:** Initialized in parallel using `Future.wait`:
    - `AddonManager.instance.initialize()`: Loads scrapers and addon manifests.
+   - `DebridService.instance.initialize()`: Restores configured Debrid accounts (Real-Debrid & Torbox).
    - `DownloadService.initialize()`: Restores persistent download tasks and queued state.
    - `GlassSettings.initialize()`: Pre-configures GPU liquid glass shader toggles.
    - `MyListService.initialize()`: Loads saved items and local favorites.
@@ -45,15 +46,18 @@ At application startup (`void main()`):
 * Consolidates movie, series, anime, and manga metadata.
 * Fetches from TMDB, AniList, and Stremio-compatible endpoints to populate `MovieDetail`, `CastMember`, `CrewMember`, `Genres`, and `Videos`.
 
-### 3.3 Playback Engine & Subtitles (`lib/pages/player/`, `libass_plugin/`, `lib/services/subtitles/`)
+### 3.3 Debrid Integration (`lib/services/debrid/`)
+* **Instant Cloud Streaming:** Connects with Real-Debrid and Torbox APIs to convert torrent hashes into high-speed direct CDN streams without depending on peer availability.
+
+### 3.4 Playback Engine & Subtitles (`lib/pages/player/`, `libass_plugin/`, `lib/services/subtitles/`)
 * **Player:** Backed by `FVP` for smooth HLS, MP4, and torrent stream playback.
 * **ASS/SSA Subtitles:** Powered by `libass_plugin` for styling and positioning complex subtitle files (essential for anime fansubs).
 * **Subtitle Providers:** Automatic fetching and extraction via `SubDL` and built-in extractors.
 
-### 3.4 Persistence & Cloud Synchronization (`lib/services/trakt/`, `lib/services/my_list/`)
-* **Local Storage:** `MyListService` and `DownloadService` persist state in `SharedPreferences` with JSON serialization.
+### 3.5 Persistence & Cloud Synchronization (`lib/services/trakt/`, `lib/services/my_list/`, `lib/services/download/`)
+* **Local Storage:** `MyListService`, `DownloadService`, and `DebridService` persist state in `SharedPreferences` with JSON serialization.
 * **Bidirectional Sync:** Trakt integration pushes and pulls watch states, history, and user lists across devices.
 
-### 3.5 UI Layer & Fluid Motion
-* **LiquidDock:** Bottom dock navigation featuring liquid lens refraction and jelly physics, pre-warmed during intro to eliminate jank.
+### 3.6 UI Architecture & Navigation Hubs (`lib/widgets/common/app_dock.dart`)
+* **AppDock:** Unified persistent dock component maintaining navigation across all primary hubs (`Media`, `Manga`, `Audiobooks`, `Music`, `Collection`).
 * **LiquidRevealRoute:** Custom circular-reveal transitions for seamless navigation across hubs.

--- a/docs/INTERNAL_ARCHITECTURE.md
+++ b/docs/INTERNAL_ARCHITECTURE.md
@@ -1,0 +1,59 @@
+# Internal Architecture & Core Mechanics — PlayTorrioV3
+
+This document provides a technical overview of **PlayTorrioV3**, detailing its core modules, data flow, streaming management, addon/scraper system, and UI architecture.
+
+---
+
+## 1. Architectural Overview
+
+PlayTorrioV3 is a multi-platform media application built with **Flutter** and accelerated by native engines (**FVP / libmdk / mpv / libass**) and a JavaScript runtime for real-time web scraping and stream resolving.
+
+```mermaid
+graph TD
+    UI[Flutter UI Layer] --> Services[Services Layer]
+    Services --> Addons[Addon Manager & JS Scrapers]
+    Services --> Metadata[Metadata & TMDB/AniList/Trakt]
+    Services --> PlayerEngine[FVP / libass Plugin Engine]
+    Services --> LocalStorage[SharedPreferences / SQLite / Cache]
+    Addons --> WebSources[Web Endpoints / Debrid / Torrent Trackers]
+```
+
+---
+
+## 2. Application Bootstrap (`main.dart`)
+
+At application startup (`void main()`):
+1. **Screen Configuration:** Immersive mode enabled (`SystemChrome.setEnabledSystemUIMode`).
+2. **Native Plugin Registration:** `fvp.registerWith()` registers the hardware-accelerated video decoding engine.
+3. **Core Asynchronous Services:** Initialized in parallel using `Future.wait`:
+   - `AddonManager.instance.initialize()`: Loads scrapers and addon manifests.
+   - `DownloadService.initialize()`: Restores persistent download tasks and queued state.
+   - `GlassSettings.initialize()`: Pre-configures GPU liquid glass shader toggles.
+   - `MyListService.initialize()`: Loads saved items and local favorites.
+   - `TraktAuthService().initialize()` & `TraktSyncService.initialize()`: Restores Trakt.tv credentials and cloud sync state.
+4. **Update Checks:** `AppUpdaterService` verifies remote GitHub releases in the background.
+
+---
+
+## 3. Core Modules & Data Flows
+
+### 3.1 Scrapers & Addon Architecture (`assets/scrapers/` & `lib/services/addon/`)
+* **JavaScript Execution:** Evaluates lightweight JS scrapers (`vidsrc.js`, `videasy.js`, `torrent_galaxy.js`, `knaben.js`, `cheerio.bundle.js`) to extract streams and metadata dynamically.
+* **Reactive Stream Feeds:** `AddonManager.streamHomeSections()` yields content sections incrementally, rendering the hero carousel instantly without blocking on slower scrapers.
+
+### 3.2 Metadata & Media Catalogs (`lib/services/metadata/`)
+* Consolidates movie, series, anime, and manga metadata.
+* Fetches from TMDB, AniList, and Stremio-compatible endpoints to populate `MovieDetail`, `CastMember`, `CrewMember`, `Genres`, and `Videos`.
+
+### 3.3 Playback Engine & Subtitles (`lib/pages/player/`, `libass_plugin/`, `lib/services/subtitles/`)
+* **Player:** Backed by `FVP` for smooth HLS, MP4, and torrent stream playback.
+* **ASS/SSA Subtitles:** Powered by `libass_plugin` for styling and positioning complex subtitle files (essential for anime fansubs).
+* **Subtitle Providers:** Automatic fetching and extraction via `SubDL` and built-in extractors.
+
+### 3.4 Persistence & Cloud Synchronization (`lib/services/trakt/`, `lib/services/my_list/`)
+* **Local Storage:** `MyListService` and `DownloadService` persist state in `SharedPreferences` with JSON serialization.
+* **Bidirectional Sync:** Trakt integration pushes and pulls watch states, history, and user lists across devices.
+
+### 3.5 UI Layer & Fluid Motion
+* **LiquidDock:** Bottom dock navigation featuring liquid lens refraction and jelly physics, pre-warmed during intro to eliminate jank.
+* **LiquidRevealRoute:** Custom circular-reveal transitions for seamless navigation across hubs.

--- a/docs/LOGS.md
+++ b/docs/LOGS.md
@@ -1,0 +1,29 @@
+# Logging & Diagnostics Guide — PlayTorrioV3
+
+This document outlines the logging strategy, error diagnostic protocols, and runtime auditing standards for **PlayTorrioV3**.
+
+---
+
+## 1. Log Levels
+
+1. **DEBUG (`[DEBUG]`):** Fine-grained execution traces of JavaScript scrapers, internal REST/GraphQL API payloads, and widget lifecycle events.
+2. **INFO (`[INFO]`):** Playback initialization events, core service boots (`AddonManager`, `DownloadService`, `MyListService`, `TraktAuthService`), and hub navigation transitions.
+3. **WARNING (`[WARN]`):** Scraper timeouts, fallback subtitle queries, and transient network recovery events.
+4. **ERROR (`[ERROR]`):** Unhandled native playback engine (`fvp`) exceptions, hardware codec decoding failures, and critical network drops.
+
+---
+
+## 2. Output & Log Sinks
+
+- **Development Console (Flutter Debug Console / Terminal):**
+  - Formatted with `HH:mm:ss.SSS` timestamps and component tags such as `[ScraperManager]`, `[PlayerCore]`, `[TraktSync]`, `[DownloadManager]`.
+- **Debug / Profiling Mode:**
+  - Shader frame metrics via `PerformanceLiquidLens` to audit GPU frame drops and jank.
+
+---
+
+## 3. Scraper Diagnostics (`assets/scrapers/`)
+
+For debugging JS extractors or verifying resolved stream URLs:
+- Use helper scripts located in the `TempJs/` directory for isolated testing via Node.js / Dart CLI.
+- Inspect JS evaluator logs to capture request parameters, custom headers (*Referer*, *User-Agent*), and JSON output formats.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,11 @@
+# PlayTorrioV3 Documentation
+
+Welcome to the technical and operational documentation for **PlayTorrioV3**.
+
+## 📚 Documentation Index
+
+- [**Internal Architecture**](./INTERNAL_ARCHITECTURE.md): Comprehensive deep-dive into the app's internal workings (startup lifecycle, JS scraper execution, `fvp`/`libass` player engine, metadata handling, and Trakt sync).
+- [**Roadmap**](./ROADMAP.md): Project evolution plan (dock simplification, Media hub, Collection center, rich Cast with headshots, and Debrid/settings integration).
+- [**Changelog**](./CHANGELOG.md): Version history and notable changes across releases.
+- [**Contributing Guide**](./CONTRIBUTING.md): Code style conventions, development workflow, and guidelines for adding scrapers and features.
+- [**Logs & Diagnostics**](./LOGS.md): Standards and specifications for runtime logging, diagnostics, and debugging.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -19,14 +19,14 @@ This document outlines the strategic roadmap for UI/UX redesign, navigation simp
 
 ## 📅 Implementation Status
 
-| Phase | Milestone | Status | Key Deliverables |
-| :--- | :--- | :--- | :--- |
-| **Phase 1** | UI & Dock Simplification | ✅ **Completed** | 7-item persistent `LiquidDock` (`AppDock`), dedicated Anime hub, Addons & Settings in dock. |
-| **Phase 2** | Collection Hub & History | ✅ **Completed** | `CollectionPage` with My List, Watchlist, History (Continue Watching), and Offline Downloads. |
-| **Phase 3** | Cast & Crew Enrichment | ✅ **Completed** | `CastMember` & `CrewMember` models, TMDB profile images, Direction section, tap-to-discover. |
-| **Phase 4** | Cloud Debrid Services | ✅ **Completed** | `DebridService` with Real-Debrid & Torbox token verification in Settings. |
-| **Phase 5** | Player Engine & Scrobbling | ✅ **Completed** | Auto-progress recording, 15s connect timeout safety, Trakt automatic scrobbler. |
-| **Phase 6** | Advanced Player Gestures | ⏳ **Pending** | Swipes for volume/brightness and auto-next episode countdown during credits. |
+| Phase       | Milestone                  | Status          | Key Deliverables                                                                              |
+|:------------|:---------------------------|:----------------|:----------------------------------------------------------------------------------------------|
+| **Phase 1** | UI & Dock Simplification   | ✅ **Completed** | 7-item persistent `LiquidDock` (`AppDock`), dedicated Anime hub, Addons & Settings in dock.   |
+| **Phase 2** | Collection Hub & History   | ✅ **Completed** | `CollectionPage` with My List, Watchlist, History (Continue Watching), and Offline Downloads. |
+| **Phase 3** | Cast & Crew Enrichment     | ✅ **Completed** | `CastMember` & `CrewMember` models, TMDB profile images, Direction section, tap-to-discover.  |
+| **Phase 4** | Cloud Debrid Services      | ✅ **Completed** | `DebridService` with Real-Debrid & Torbox token verification in Settings.                     |
+| **Phase 5** | Player Engine & Scrobbling | ✅ **Completed** | Auto-progress recording, 15s connect timeout safety, Trakt automatic scrobbler.               |
+| **Phase 6** | Advanced Player Gestures   | ⏳ **Pending**   | Swipes for volume/brightness and auto-next episode countdown during credits.                  |
 
 ---
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -6,13 +6,13 @@ This document outlines the strategic roadmap for UI/UX redesign, navigation simp
 
 ## 🎯 Primary Goals
 
-1. **Streamlined Navigation:** [COMPLETED] Reduced bottom dock clutter down to 5 essential persistent hubs.
-2. **Unified "Collection" Hub:** [COMPLETED] Consolidated My List, Watchlist, Playback History, and Offline Downloads manager.
-3. **"Media" Hub:** [COMPLETED] Evolved the home screen into a unified Media Hub with native Anime integration.
-4. **Rich Visual Cast & Crew:** [COMPLETED] Displayed high-resolution TMDB headshots for actors and directors with character role mapping.
+1. **Streamlined Navigation:** [COMPLETED] Reduced bottom dock clutter down to 7 dedicated persistent hubs (`Movies & Series`, `Anime`, `Manga`, `Audiobooks`, `Music`, `Collection`, `Settings`).
+2. **Unified "Collection" Hub:** [COMPLETED] Consolidated My List, Watchlist, Playback History (Continue Watching), and Offline Downloads manager.
+3. **Dedicated "Anime" Hub:** [COMPLETED] Placed Anime into its own dedicated hub directly next to Movies & Series.
+4. **Rich Visual Cast & Crew:** [COMPLETED] Displayed high-resolution TMDB headshots for actors and directors with character role mapping and direct filmography search.
 5. **Debrid Service Integration (Real-Debrid / Torbox):** [COMPLETED] Added Debrid provider manager in Settings for high-speed cloud stream resolving.
-6. **Advanced Video Player:** Auto-Next/Binge watching, audio track & subtitle switcher, `libass` anime subtitle styling, and gesture controls.
-7. **Dual Scrobbling (Trakt + AniList):** Automatic progress tracking for movies/series (Trakt) and anime (AniList).
+6. **Robust Video Player & Timeout Protection:** [COMPLETED] 15s initialization timeout with friendly quota/server errors, auto-progress tracking, and resume support.
+7. **Automated Scrobbling (Trakt.tv):** [COMPLETED] Real-time scrobbler reporting periodic playback progress and completion triggers to Trakt.tv.
 8. **Addons Management in Settings:** [COMPLETED] Centralized scraper and plugin configuration inside the settings view.
 
 ---
@@ -21,47 +21,51 @@ This document outlines the strategic roadmap for UI/UX redesign, navigation simp
 
 | Phase | Milestone | Status | Key Deliverables |
 | :--- | :--- | :--- | :--- |
-| **Phase 1** | UI & Dock Simplification | ✅ **Completed** | 5-item `LiquidDock`, persistent across all hubs (`AppDock`), Addons moved to Settings. |
-| **Phase 2** | Collection & Media Hub | ✅ **Completed** | `CollectionPage` with My List, Watchlist, and Offline Downloads; Media Hub with Anime chip. |
+| **Phase 1** | UI & Dock Simplification | ✅ **Completed** | 7-item persistent `LiquidDock` (`AppDock`), dedicated Anime hub, Addons & Settings in dock. |
+| **Phase 2** | Collection Hub & History | ✅ **Completed** | `CollectionPage` with My List, Watchlist, History (Continue Watching), and Offline Downloads. |
 | **Phase 3** | Cast & Crew Enrichment | ✅ **Completed** | `CastMember` & `CrewMember` models, TMDB profile images, Direction section, tap-to-discover. |
 | **Phase 4** | Cloud Debrid Services | ✅ **Completed** | `DebridService` with Real-Debrid & Torbox token verification in Settings. |
-| **Phase 5** | Player Engine & Scrobbling | ⏳ **In Progress** | Player gesture controls, track selectors, and Trakt/AniList automatic scrobblers. |
+| **Phase 5** | Player Engine & Scrobbling | ✅ **Completed** | Auto-progress recording, 15s connect timeout safety, Trakt automatic scrobbler. |
+| **Phase 6** | Advanced Player Gestures | ⏳ **Pending** | Swipes for volume/brightness and auto-next episode countdown during credits. |
 
 ---
 
 ## 📌 Module Breakdown & Progress Details
 
 ### 1. LiquidDock & Main Navigation [COMPLETED]
-* ✅ **Simplified Layout:** 5 primary persistent hubs:
-  - 🎬 **Media:** Unified hub for Movies, TV Series, and Anime.
+* ✅ **Layout:** 7 dedicated persistent hubs:
+  - 🎬 **Movies & Series:** VOD movies and series catalogs.
+  - 🎭 **Anime:** Dedicated AniList hub with airing schedules and genre filters.
   - 📖 **Manga:** Manga/comic reader and library.
   - 🎧 **Audiobooks:** Curated audiobook scraper and player.
   - 🎵 **Music:** Octave music streaming and playlists.
-  - 📂 **Collection:** User lists, Watchlist, and Offline Downloads.
+  - 📂 **Collection:** User lists, Watchlist, History, and Offline Downloads.
+  - ⚙️ **Settings:** Addons, Debrid, Trakt, and shader settings.
 * ✅ **Persistent Dock:** `AppDock` keeps bottom navigation visible and accessible from all pages without disappearing.
 
 ### 2. Collection Hub (`lib/pages/collection/`) [COMPLETED]
 * ✅ **Tab 1 - My List / Favorites:** Filter by Movie/Series/Anime, sort by recent/title/year, sync with Trakt.
 * ✅ **Tab 2 - Watchlist:** Integrated watchlist tracking for saved media.
-* ✅ **Tab 3 - Downloads:** Offline download manager (`DownloadService`) supporting queue tracking and status monitoring.
+* ✅ **Tab 3 - History:** Granular resume points and progress bars for in-progress and completed items.
+* ✅ **Tab 4 - Downloads:** Offline download manager (`DownloadService`) supporting queue tracking and status monitoring.
 
-### 3. Media Hub & Anime Integration [COMPLETED]
-* ✅ Top bar quick launch chip in `HomePage` providing direct fluid access to `AnimePage`.
-
-### 4. Cast & Directors with Images (`lib/pages/details/`) [COMPLETED]
+### 3. Cast & Directors with Images (`lib/pages/details/`) [COMPLETED]
 * ✅ `CastMember` model parsing TMDB profile URLs and character roles.
 * ✅ Dedicated `Direction` section with director avatar and tap-to-discover filmography search.
-* ✅ Smooth fallback to initial badges with animated color pairs.
+* ✅ Button updated to `"Add to Collection"` / `"In Collection"`.
 
-### 5. Debrid Providers (`lib/services/debrid/`) [COMPLETED]
+### 4. Debrid Providers (`lib/services/debrid/`) [COMPLETED]
 * ✅ Support for **Real-Debrid** and **Torbox** account verification and persistent token storage.
 * ✅ Seamless connection management inside `SettingsPage`.
 
-### 6. Video Player Enhancements (`lib/pages/player/`) [PLANNED]
-* Touch & mouse gesture controls for brightness, volume, and seeking.
-* Auto-next episode prompt during credits.
-* Embedded MKV/MP4 audio track and subtitle selector.
+### 5. Video Player & Scrobbling (`lib/pages/player/`, `lib/services/trakt/`) [COMPLETED]
+* ✅ 15-second initialization timeout guard preventing video loading lockups.
+* ✅ Automatic periodic progress sync and playback resumption from history.
+* ✅ Automated Trakt.tv scrobbling during playback and on completion.
 
-### 7. Automated Scrobbling (`Trakt` & `AniList`) [PLANNED]
-* Trakt background scrobbler at 80-90% playback progress.
-* AniList episode watch-count synchronization.
+---
+
+## 🔮 Pending Future Enhancements
+
+1. **In-Player Gestures:** Vertical swipes for volume and brightness, horizontal swipe for scrubbing.
+2. **Auto-Next Episode Dialog:** Automatic prompt countdown in the final credits to jump to next chapter.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,91 @@
+# Project Roadmap — PlayTorrioV3
+
+This document outlines the strategic roadmap for UI/UX redesign, navigation simplification, modular refactoring, streaming capabilities, and core functional enhancements for **PlayTorrioV3**.
+
+---
+
+## 🎯 Primary Goals
+
+1. **Streamlined Navigation:** Reduce bottom dock clutter down to essential hubs for a cleaner user experience.
+2. **Unified "Collection" Hub:** Consolidate My List, Watchlist, Playback History, and Offline Downloads manager.
+3. **"Media" Hub:** Evolve the home screen into a unified Media Hub with native Anime integration.
+4. **Rich Visual Cast & Crew:** Display high-resolution TMDB headshots for actors and directors with direct navigation to their filmographies.
+5. **Debrid Service Integration (Real-Debrid / AllDebrid / Torbox):** Enable high-speed cloud torrent streaming without peer/seed dependency.
+6. **Advanced Video Player:** Auto-Next/Binge watching, audio track & subtitle switcher, `libass` anime subtitle styling, and gesture controls.
+7. **Dual Scrobbling (Trakt + AniList):** Automatic progress tracking for movies/series (Trakt) and anime (AniList).
+8. **Addons Management in Settings:** Centralize scraper and plugin configuration inside the settings view.
+
+---
+
+## 📅 Implementation Phases
+
+```mermaid
+gantt
+    title PlayTorrioV3 Strategic Roadmap
+    dateFormat  YYYY-MM-DD
+    section Phase 1: UI & Navigation
+    Dock Simplification                :2026-08-22, 5d
+    Addons & Scrapers to Settings      :2026-08-25, 4d
+    section Phase 2: Collection & Media
+    Refactor MyList to Collection      :2026-08-29, 6d
+    Home -> Media Hub + Anime          :2026-09-03, 5d
+    Cast & Director with TMDB photos   :2026-09-07, 5d
+    section Phase 3: Streaming & Debrid
+    Real-Debrid / Torbox Support       :2026-09-12, 7d
+    Offline Downloads Manager          :2026-09-18, 6d
+    section Phase 4: Player & Sync
+    Player Enhancements (Audio/Subs)   :2026-09-24, 7d
+    Trakt + AniList Scrobblers         :2026-09-30, 5d
+    Shaders & Performance Tuning       :2026-10-04, 6d
+```
+
+---
+
+## 📌 Module Breakdown & Critical Enhancements
+
+### 1. LiquidDock & Main Navigation
+* **Simplified Layout (Essential Hubs):**
+  - 🎬 **Media:** Unified hub (Movies, TV Shows, and Anime with quick category filters).
+  - 📖 **Manga:** Manga/comic reader and library.
+  - 🎧 **Audio:** Music (Octave) and Audiobooks (AudiobookBay) with switcher.
+  - 📂 **Collection:** Favorites, Watchlist, Playback History, and Downloads.
+
+### 2. Collection (`lib/pages/collection/`)
+* **Tab 1 - My List / Favorites:** User-saved media with custom sorting (date, title, year) and filtering.
+* **Tab 2 - Watchlist:** Integrated watchlist tracking across providers.
+* **Tab 3 - History & Continue Watching:** Granular playback resumption saved to exact timestamp.
+* **Tab 4 - Downloads:** Full-featured offline manager supporting download queues, pause/resume, and local playback.
+
+### 3. Media Hub & Anime
+* Unify `HomePage` and `AnimePage`:
+  - Top category selector: *All*, *Movies*, *Series*, *Anime*.
+  - Airing schedule carousel powered by AniList.
+  - Unified search across all content types.
+
+### 4. Cast & Directors with Images (`lib/pages/details/`)
+* Seamless `profile_path` integration from TMDB using `CachedNetworkImage` with fallback initials.
+* Filmography exploration: clicking an actor or director opens `DiscoverPage` with their full work.
+* Character role labels alongside actor names.
+
+### 5. Debrid Providers (Real-Debrid, AllDebrid, Torbox, Premiumize)
+* **Why Critical:** Eliminates dependence on torrent seeds, prevents ISP throttling, and enables instant 4K HDR playback via direct HTTP CDN links.
+* **Functionality:**
+  - OAuth / API Key login in Settings.
+  - Instant cache check for torrent hashes.
+  - Transparent magnet-to-stream resolution.
+
+### 6. Video Player Enhancements (`lib/pages/player/`)
+* **Touch & Mouse Gestures:** Vertical swipes for volume (right) and brightness (left); horizontal swipe for seeking.
+* **Auto-Play / Next Episode:** Countdown prompt during credits to load the next episode automatically.
+* **Audio Track & Subtitle Switcher:** In-player selection of embedded container tracks (MKV/MP4) and on-demand subtitle downloads (`SubDL`).
+* **`libass_plugin` Integration:** Advanced SSA/ASS rendering for stylized anime subtitles and fonts.
+
+### 7. Automated Scrobbling & Cloud Sync
+* **Trakt.tv Scrobbler:** Automatically mark media as watched once 80-90% is completed.
+* **AniList Scrobbler:** Automatically sync watched anime episode counts to the user's AniList profile.
+
+### 8. Addons & Scrapers Management (`lib/pages/settings/`)
+* Move addon administration out of the primary dock:
+  - Addon repository browser.
+  - Per-scraper toggle switches.
+  - Over-the-air hot updates for JS scrapers.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -6,86 +6,62 @@ This document outlines the strategic roadmap for UI/UX redesign, navigation simp
 
 ## 🎯 Primary Goals
 
-1. **Streamlined Navigation:** Reduce bottom dock clutter down to essential hubs for a cleaner user experience.
-2. **Unified "Collection" Hub:** Consolidate My List, Watchlist, Playback History, and Offline Downloads manager.
-3. **"Media" Hub:** Evolve the home screen into a unified Media Hub with native Anime integration.
-4. **Rich Visual Cast & Crew:** Display high-resolution TMDB headshots for actors and directors with direct navigation to their filmographies.
-5. **Debrid Service Integration (Real-Debrid / AllDebrid / Torbox):** Enable high-speed cloud torrent streaming without peer/seed dependency.
+1. **Streamlined Navigation:** [COMPLETED] Reduced bottom dock clutter down to 5 essential persistent hubs.
+2. **Unified "Collection" Hub:** [COMPLETED] Consolidated My List, Watchlist, Playback History, and Offline Downloads manager.
+3. **"Media" Hub:** [COMPLETED] Evolved the home screen into a unified Media Hub with native Anime integration.
+4. **Rich Visual Cast & Crew:** [COMPLETED] Displayed high-resolution TMDB headshots for actors and directors with character role mapping.
+5. **Debrid Service Integration (Real-Debrid / Torbox):** [COMPLETED] Added Debrid provider manager in Settings for high-speed cloud stream resolving.
 6. **Advanced Video Player:** Auto-Next/Binge watching, audio track & subtitle switcher, `libass` anime subtitle styling, and gesture controls.
 7. **Dual Scrobbling (Trakt + AniList):** Automatic progress tracking for movies/series (Trakt) and anime (AniList).
-8. **Addons Management in Settings:** Centralize scraper and plugin configuration inside the settings view.
+8. **Addons Management in Settings:** [COMPLETED] Centralized scraper and plugin configuration inside the settings view.
 
 ---
 
-## 📅 Implementation Phases
+## 📅 Implementation Status
 
-```mermaid
-gantt
-    title PlayTorrioV3 Strategic Roadmap
-    dateFormat  YYYY-MM-DD
-    section Phase 1: UI & Navigation
-    Dock Simplification                :2026-08-22, 5d
-    Addons & Scrapers to Settings      :2026-08-25, 4d
-    section Phase 2: Collection & Media
-    Refactor MyList to Collection      :2026-08-29, 6d
-    Home -> Media Hub + Anime          :2026-09-03, 5d
-    Cast & Director with TMDB photos   :2026-09-07, 5d
-    section Phase 3: Streaming & Debrid
-    Real-Debrid / Torbox Support       :2026-09-12, 7d
-    Offline Downloads Manager          :2026-09-18, 6d
-    section Phase 4: Player & Sync
-    Player Enhancements (Audio/Subs)   :2026-09-24, 7d
-    Trakt + AniList Scrobblers         :2026-09-30, 5d
-    Shaders & Performance Tuning       :2026-10-04, 6d
-```
+| Phase | Milestone | Status | Key Deliverables |
+| :--- | :--- | :--- | :--- |
+| **Phase 1** | UI & Dock Simplification | ✅ **Completed** | 5-item `LiquidDock`, persistent across all hubs (`AppDock`), Addons moved to Settings. |
+| **Phase 2** | Collection & Media Hub | ✅ **Completed** | `CollectionPage` with My List, Watchlist, and Offline Downloads; Media Hub with Anime chip. |
+| **Phase 3** | Cast & Crew Enrichment | ✅ **Completed** | `CastMember` & `CrewMember` models, TMDB profile images, Direction section, tap-to-discover. |
+| **Phase 4** | Cloud Debrid Services | ✅ **Completed** | `DebridService` with Real-Debrid & Torbox token verification in Settings. |
+| **Phase 5** | Player Engine & Scrobbling | ⏳ **In Progress** | Player gesture controls, track selectors, and Trakt/AniList automatic scrobblers. |
 
 ---
 
-## 📌 Module Breakdown & Critical Enhancements
+## 📌 Module Breakdown & Progress Details
 
-### 1. LiquidDock & Main Navigation
-* **Simplified Layout (Essential Hubs):**
-  - 🎬 **Media:** Unified hub (Movies, TV Shows, and Anime with quick category filters).
+### 1. LiquidDock & Main Navigation [COMPLETED]
+* ✅ **Simplified Layout:** 5 primary persistent hubs:
+  - 🎬 **Media:** Unified hub for Movies, TV Series, and Anime.
   - 📖 **Manga:** Manga/comic reader and library.
-  - 🎧 **Audio:** Music (Octave) and Audiobooks (AudiobookBay) with switcher.
-  - 📂 **Collection:** Favorites, Watchlist, Playback History, and Downloads.
+  - 🎧 **Audiobooks:** Curated audiobook scraper and player.
+  - 🎵 **Music:** Octave music streaming and playlists.
+  - 📂 **Collection:** User lists, Watchlist, and Offline Downloads.
+* ✅ **Persistent Dock:** `AppDock` keeps bottom navigation visible and accessible from all pages without disappearing.
 
-### 2. Collection (`lib/pages/collection/`)
-* **Tab 1 - My List / Favorites:** User-saved media with custom sorting (date, title, year) and filtering.
-* **Tab 2 - Watchlist:** Integrated watchlist tracking across providers.
-* **Tab 3 - History & Continue Watching:** Granular playback resumption saved to exact timestamp.
-* **Tab 4 - Downloads:** Full-featured offline manager supporting download queues, pause/resume, and local playback.
+### 2. Collection Hub (`lib/pages/collection/`) [COMPLETED]
+* ✅ **Tab 1 - My List / Favorites:** Filter by Movie/Series/Anime, sort by recent/title/year, sync with Trakt.
+* ✅ **Tab 2 - Watchlist:** Integrated watchlist tracking for saved media.
+* ✅ **Tab 3 - Downloads:** Offline download manager (`DownloadService`) supporting queue tracking and status monitoring.
 
-### 3. Media Hub & Anime
-* Unify `HomePage` and `AnimePage`:
-  - Top category selector: *All*, *Movies*, *Series*, *Anime*.
-  - Airing schedule carousel powered by AniList.
-  - Unified search across all content types.
+### 3. Media Hub & Anime Integration [COMPLETED]
+* ✅ Top bar quick launch chip in `HomePage` providing direct fluid access to `AnimePage`.
 
-### 4. Cast & Directors with Images (`lib/pages/details/`)
-* Seamless `profile_path` integration from TMDB using `CachedNetworkImage` with fallback initials.
-* Filmography exploration: clicking an actor or director opens `DiscoverPage` with their full work.
-* Character role labels alongside actor names.
+### 4. Cast & Directors with Images (`lib/pages/details/`) [COMPLETED]
+* ✅ `CastMember` model parsing TMDB profile URLs and character roles.
+* ✅ Dedicated `Direction` section with director avatar and tap-to-discover filmography search.
+* ✅ Smooth fallback to initial badges with animated color pairs.
 
-### 5. Debrid Providers (Real-Debrid, AllDebrid, Torbox, Premiumize)
-* **Why Critical:** Eliminates dependence on torrent seeds, prevents ISP throttling, and enables instant 4K HDR playback via direct HTTP CDN links.
-* **Functionality:**
-  - OAuth / API Key login in Settings.
-  - Instant cache check for torrent hashes.
-  - Transparent magnet-to-stream resolution.
+### 5. Debrid Providers (`lib/services/debrid/`) [COMPLETED]
+* ✅ Support for **Real-Debrid** and **Torbox** account verification and persistent token storage.
+* ✅ Seamless connection management inside `SettingsPage`.
 
-### 6. Video Player Enhancements (`lib/pages/player/`)
-* **Touch & Mouse Gestures:** Vertical swipes for volume (right) and brightness (left); horizontal swipe for seeking.
-* **Auto-Play / Next Episode:** Countdown prompt during credits to load the next episode automatically.
-* **Audio Track & Subtitle Switcher:** In-player selection of embedded container tracks (MKV/MP4) and on-demand subtitle downloads (`SubDL`).
-* **`libass_plugin` Integration:** Advanced SSA/ASS rendering for stylized anime subtitles and fonts.
+### 6. Video Player Enhancements (`lib/pages/player/`) [PLANNED]
+* Touch & mouse gesture controls for brightness, volume, and seeking.
+* Auto-next episode prompt during credits.
+* Embedded MKV/MP4 audio track and subtitle selector.
 
-### 7. Automated Scrobbling & Cloud Sync
-* **Trakt.tv Scrobbler:** Automatically mark media as watched once 80-90% is completed.
-* **AniList Scrobbler:** Automatically sync watched anime episode counts to the user's AniList profile.
-
-### 8. Addons & Scrapers Management (`lib/pages/settings/`)
-* Move addon administration out of the primary dock:
-  - Addon repository browser.
-  - Per-scraper toggle switches.
-  - Over-the-air hot updates for JS scrapers.
+### 7. Automated Scrobbling (`Trakt` & `AniList`) [PLANNED]
+* Trakt background scrobbler at 80-90% playback progress.
+* AniList episode watch-count synchronization.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:fvp/fvp.dart' as fvp;
 import './pages/home/home_page.dart';
 import './services/addon/addon_manager.dart';
 import './services/app_updater_service.dart';
+import './services/debrid/debrid_service.dart';
 import './services/download/download_service.dart';
 import './services/glass_settings.dart';
 import './services/my_list/my_list_service.dart';
@@ -21,6 +22,7 @@ void main() async {
   fvp.registerWith();
   await Future.wait([
     AddonManager.instance.initialize(),
+    DebridService.instance.initialize(),
     DownloadService.initialize(),
     GlassSettings.initialize(),
     MyListService.initialize(),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,6 +10,7 @@ import './services/debrid/debrid_service.dart';
 import './services/download/download_service.dart';
 import './services/glass_settings.dart';
 import './services/my_list/my_list_service.dart';
+import './services/playback/playback_history_service.dart';
 import './services/trakt/trakt_auth_service.dart';
 import './services/trakt/trakt_sync_service.dart';
 import './widgets/update_dialog.dart';
@@ -26,6 +27,7 @@ void main() async {
     DownloadService.initialize(),
     GlassSettings.initialize(),
     MyListService.initialize(),
+    PlaybackHistoryService.initialize(),
     TraktAuthService().initialize(),
     TraktSyncService.initialize(),
   ]);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:fvp/fvp.dart' as fvp;
 import './pages/home/home_page.dart';
 import './services/addon/addon_manager.dart';
 import './services/app_updater_service.dart';
+import './services/download/download_service.dart';
 import './services/glass_settings.dart';
 import './services/my_list/my_list_service.dart';
 import './services/trakt/trakt_auth_service.dart';
@@ -20,6 +21,7 @@ void main() async {
   fvp.registerWith();
   await Future.wait([
     AddonManager.instance.initialize(),
+    DownloadService.initialize(),
     GlassSettings.initialize(),
     MyListService.initialize(),
     TraktAuthService().initialize(),

--- a/lib/models/debrid/debrid_account.dart
+++ b/lib/models/debrid/debrid_account.dart
@@ -1,0 +1,54 @@
+enum DebridProvider {
+  realDebrid('Real-Debrid', 'https://api.real-debrid.com/rest/1.0'),
+  torbox('Torbox', 'https://api.torbox.app/v1/api'),
+  allDebrid('AllDebrid', 'https://api.alldebrid.com/v4'),
+  premiumize('Premiumize', 'https://www.premiumize.me/api');
+
+  final String displayName;
+  final String apiUrl;
+  const DebridProvider(this.displayName, this.apiUrl);
+}
+
+class DebridAccount {
+  final DebridProvider provider;
+  final String apiKey;
+  final String? username;
+  final String? email;
+  final DateTime? expirationDate;
+  final bool isPremium;
+
+  const DebridAccount({
+    required this.provider,
+    required this.apiKey,
+    this.username,
+    this.email,
+    this.expirationDate,
+    this.isPremium = false,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'provider': provider.name,
+        'apiKey': apiKey,
+        if (username != null) 'username': username,
+        if (email != null) 'email': email,
+        if (expirationDate != null)
+          'expirationDate': expirationDate!.toIso8601String(),
+        'isPremium': isPremium,
+      };
+
+  factory DebridAccount.fromJson(Map<String, dynamic> json) {
+    return DebridAccount(
+      provider: DebridProvider.values.firstWhere(
+        (p) => p.name == json['provider'],
+        orElse: () => DebridProvider.realDebrid,
+      ),
+      apiKey: json['apiKey'] as String? ?? '',
+      username: json['username'] as String?,
+      email: json['email'] as String?,
+      expirationDate: json['expirationDate'] != null
+          ? DateTime.tryParse(json['expirationDate'] as String)
+          : null,
+      isPremium: json['isPremium'] as bool? ?? false,
+    );
+  }
+}

--- a/lib/models/download/download_item.dart
+++ b/lib/models/download/download_item.dart
@@ -1,0 +1,116 @@
+enum DownloadStatus {
+  queued,
+  downloading,
+  paused,
+  completed,
+  failed,
+}
+
+class DownloadItem {
+  final String id;
+  final String title;
+  final String? poster;
+  final String? episodeTitle;
+  final int? seasonNumber;
+  final int? episodeNumber;
+  final String type; // 'movie' or 'series' or 'anime'
+  final String downloadUrl;
+  final String? localFilePath;
+  final double progress; // 0.0 to 1.0
+  final DownloadStatus status;
+  final int totalBytes;
+  final int receivedBytes;
+  final DateTime createdAt;
+
+  const DownloadItem({
+    required this.id,
+    required this.title,
+    this.poster,
+    this.episodeTitle,
+    this.seasonNumber,
+    this.episodeNumber,
+    this.type = 'movie',
+    required this.downloadUrl,
+    this.localFilePath,
+    this.progress = 0.0,
+    this.status = DownloadStatus.queued,
+    this.totalBytes = 0,
+    this.receivedBytes = 0,
+    required this.createdAt,
+  });
+
+  DownloadItem copyWith({
+    String? id,
+    String? title,
+    String? poster,
+    String? episodeTitle,
+    int? seasonNumber,
+    int? episodeNumber,
+    String? type,
+    String? downloadUrl,
+    String? localFilePath,
+    double? progress,
+    DownloadStatus? status,
+    int? totalBytes,
+    int? receivedBytes,
+    DateTime? createdAt,
+  }) {
+    return DownloadItem(
+      id: id ?? this.id,
+      title: title ?? this.title,
+      poster: poster ?? this.poster,
+      episodeTitle: episodeTitle ?? this.episodeTitle,
+      seasonNumber: seasonNumber ?? this.seasonNumber,
+      episodeNumber: episodeNumber ?? this.episodeNumber,
+      type: type ?? this.type,
+      downloadUrl: downloadUrl ?? this.downloadUrl,
+      localFilePath: localFilePath ?? this.localFilePath,
+      progress: progress ?? this.progress,
+      status: status ?? this.status,
+      totalBytes: totalBytes ?? this.totalBytes,
+      receivedBytes: receivedBytes ?? this.receivedBytes,
+      createdAt: createdAt ?? this.createdAt,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'title': title,
+        'poster': poster,
+        'episodeTitle': episodeTitle,
+        'seasonNumber': seasonNumber,
+        'episodeNumber': episodeNumber,
+        'type': type,
+        'downloadUrl': downloadUrl,
+        'localFilePath': localFilePath,
+        'progress': progress,
+        'status': status.name,
+        'totalBytes': totalBytes,
+        'receivedBytes': receivedBytes,
+        'createdAt': createdAt.toIso8601String(),
+      };
+
+  factory DownloadItem.fromJson(Map<String, dynamic> json) {
+    return DownloadItem(
+      id: json['id'] as String? ?? '',
+      title: json['title'] as String? ?? 'Unknown',
+      poster: json['poster'] as String?,
+      episodeTitle: json['episodeTitle'] as String?,
+      seasonNumber: json['seasonNumber'] as int?,
+      episodeNumber: json['episodeNumber'] as int?,
+      type: json['type'] as String? ?? 'movie',
+      downloadUrl: json['downloadUrl'] as String? ?? '',
+      localFilePath: json['localFilePath'] as String?,
+      progress: (json['progress'] as num?)?.toDouble() ?? 0.0,
+      status: DownloadStatus.values.firstWhere(
+        (e) => e.name == json['status'],
+        orElse: () => DownloadStatus.queued,
+      ),
+      totalBytes: json['totalBytes'] as int? ?? 0,
+      receivedBytes: json['receivedBytes'] as int? ?? 0,
+      createdAt: json['createdAt'] != null
+          ? DateTime.tryParse(json['createdAt'] as String) ?? DateTime.now()
+          : DateTime.now(),
+    );
+  }
+}

--- a/lib/models/movie/cast_member.dart
+++ b/lib/models/movie/cast_member.dart
@@ -1,0 +1,79 @@
+class CastMember {
+  final String name;
+  final String? character;
+  final String? profileUrl;
+  final String? tmdbId;
+
+  const CastMember({
+    required this.name,
+    this.character,
+    this.profileUrl,
+    this.tmdbId,
+  });
+
+  factory CastMember.fromJson(dynamic json) {
+    if (json is String) {
+      return CastMember(name: json);
+    }
+    if (json is Map<String, dynamic>) {
+      final name = json['name']?.toString() ?? json['title']?.toString() ?? 'Unknown';
+      final character = json['character']?.toString() ?? json['role']?.toString();
+      final profile = json['profile_path']?.toString() ??
+          json['image']?.toString() ??
+          json['photo']?.toString() ??
+          json['profile']?.toString();
+      final profileUrl = profile != null && profile.isNotEmpty
+          ? (profile.startsWith('http') ? profile : 'https://image.tmdb.org/t/p/w276_and_h350_face$profile')
+          : null;
+      final tmdbId = json['id']?.toString() ?? json['tmdb_id']?.toString();
+
+      return CastMember(
+        name: name,
+        character: character,
+        profileUrl: profileUrl,
+        tmdbId: tmdbId,
+      );
+    }
+    return CastMember(name: json?.toString() ?? 'Unknown');
+  }
+
+  Map<String, dynamic> toJson() => {
+        'name': name,
+        if (character != null) 'character': character,
+        if (profileUrl != null) 'profileUrl': profileUrl,
+        if (tmdbId != null) 'tmdbId': tmdbId,
+      };
+}
+
+class CrewMember {
+  final String name;
+  final String job;
+  final String? profileUrl;
+
+  const CrewMember({
+    required this.name,
+    required this.job,
+    this.profileUrl,
+  });
+
+  factory CrewMember.fromJson(dynamic json, {String job = 'Director'}) {
+    if (json is String) {
+      return CrewMember(name: json, job: job);
+    }
+    if (json is Map<String, dynamic>) {
+      final name = json['name']?.toString() ?? 'Unknown';
+      final role = json['job']?.toString() ?? json['role']?.toString() ?? job;
+      final profile = json['profile_path']?.toString() ?? json['photo']?.toString() ?? json['image']?.toString();
+      final profileUrl = profile != null && profile.isNotEmpty
+          ? (profile.startsWith('http') ? profile : 'https://image.tmdb.org/t/p/w276_and_h350_face$profile')
+          : null;
+
+      return CrewMember(
+        name: name,
+        job: role,
+        profileUrl: profileUrl,
+      );
+    }
+    return CrewMember(name: json?.toString() ?? 'Unknown', job: job);
+  }
+}

--- a/lib/models/movie/movie_detail.dart
+++ b/lib/models/movie/movie_detail.dart
@@ -1,3 +1,4 @@
+import 'cast_member.dart';
 import 'link.dart';
 import 'video.dart';
 
@@ -13,7 +14,9 @@ class MovieDetail {
   final String? imdbRating;
   final List<String> genres;
   final List<String> cast;
+  final List<CastMember> castMembers;
   final List<String> director;
+  final List<CrewMember> directorsList;
   final String? runtime;
   final List<Link> links;
   final List<Video> videos;
@@ -31,7 +34,9 @@ class MovieDetail {
     this.imdbRating,
     this.genres = const [],
     this.cast = const [],
+    this.castMembers = const [],
     this.director = const [],
+    this.directorsList = const [],
     this.runtime,
     this.links = const [],
     this.videos = const [],
@@ -39,6 +44,14 @@ class MovieDetail {
   });
 
   factory MovieDetail.fromJson(Map<String, dynamic> json) {
+    final rawCast = json['cast'];
+    final castStrings = _parseStringList(rawCast);
+    final parsedCastMembers = _parseCastMembers(rawCast);
+
+    final rawDirector = json['director'] ?? json['directors'];
+    final directorStrings = _parseStringList(rawDirector);
+    final parsedDirectors = _parseDirectors(rawDirector);
+
     return MovieDetail(
       id: json['id']?.toString() ?? '',
       type: json['type']?.toString() ?? 'movie',
@@ -50,8 +63,10 @@ class MovieDetail {
       year: json['releaseInfo']?.toString() ?? json['year']?.toString(),
       imdbRating: json['imdbRating']?.toString(),
       genres: _parseStringList(json['genres']),
-      cast: _parseStringList(json['cast']),
-      director: _parseStringList(json['director']),
+      cast: castStrings,
+      castMembers: parsedCastMembers,
+      director: directorStrings,
+      directorsList: parsedDirectors,
       runtime: json['runtime']?.toString(),
       links: (json['links'] as List<dynamic>?)
               ?.map((e) => Link.fromJson(e as Map<String, dynamic>))
@@ -66,9 +81,36 @@ class MovieDetail {
   }
 }
 
+List<CastMember> _parseCastMembers(dynamic value) {
+  if (value == null) return [];
+  if (value is List) {
+    return value.map((e) => CastMember.fromJson(e)).toList();
+  }
+  if (value is String) {
+    return [CastMember(name: value)];
+  }
+  return [];
+}
+
+List<CrewMember> _parseDirectors(dynamic value) {
+  if (value == null) return [];
+  if (value is List) {
+    return value.map((e) => CrewMember.fromJson(e, job: 'Director')).toList();
+  }
+  if (value is String) {
+    return [CrewMember(name: value, job: 'Director')];
+  }
+  return [];
+}
+
 List<String> _parseStringList(dynamic value) {
   if (value == null) return [];
   if (value is String) return [value];
-  if (value is List) return value.map((e) => e.toString()).toList();
+  if (value is List) {
+    return value.map((e) {
+      if (e is Map) return (e['name'] ?? e['title'] ?? '').toString();
+      return e.toString();
+    }).where((s) => s.isNotEmpty).toList();
+  }
   return [];
 }

--- a/lib/models/my_list/my_list_item.dart
+++ b/lib/models/my_list/my_list_item.dart
@@ -10,6 +10,7 @@ class MyListItem {
   final String? poster;
   final DateTime addedAt;
   final MyListSource source;
+  final bool isWatchlist;
 
   const MyListItem({
     this.traktId,
@@ -21,6 +22,7 @@ class MyListItem {
     this.poster,
     required this.addedAt,
     this.source = MyListSource.local,
+    this.isWatchlist = false,
   });
 
   String get uniqueKey {
@@ -102,6 +104,7 @@ class MyListItem {
       'poster': poster,
       'addedAt': addedAt.toIso8601String(),
       'source': source.name,
+      'isWatchlist': isWatchlist,
     };
   }
 
@@ -118,6 +121,7 @@ class MyListItem {
           ? DateTime.tryParse(json['addedAt'].toString()) ?? DateTime.now()
           : DateTime.now(),
       source: json['source'] == 'trakt' ? MyListSource.trakt : MyListSource.local,
+      isWatchlist: json['isWatchlist'] as bool? ?? false,
     );
   }
 

--- a/lib/models/playback/playback_history_item.dart
+++ b/lib/models/playback/playback_history_item.dart
@@ -1,0 +1,93 @@
+class PlaybackHistoryItem {
+  final String id;
+  final String title;
+  final String? poster;
+  final String? backdrop;
+  final String type; // 'movie' or 'series' or 'anime'
+  final String? episodeTitle;
+  final int? seasonNumber;
+  final int? episodeNumber;
+  final Duration position;
+  final Duration duration;
+  final DateTime lastWatched;
+
+  const PlaybackHistoryItem({
+    required this.id,
+    required this.title,
+    this.poster,
+    this.backdrop,
+    this.type = 'movie',
+    this.episodeTitle,
+    this.seasonNumber,
+    this.episodeNumber,
+    required this.position,
+    required this.duration,
+    required this.lastWatched,
+  });
+
+  double get progressPercentage => duration.inMilliseconds > 0
+      ? (position.inMilliseconds / duration.inMilliseconds).clamp(0.0, 1.0)
+      : 0.0;
+
+  bool get isCompleted => progressPercentage >= 0.90;
+
+  PlaybackHistoryItem copyWith({
+    String? id,
+    String? title,
+    String? poster,
+    String? backdrop,
+    String? type,
+    String? episodeTitle,
+    int? seasonNumber,
+    int? episodeNumber,
+    Duration? position,
+    Duration? duration,
+    DateTime? lastWatched,
+  }) {
+    return PlaybackHistoryItem(
+      id: id ?? this.id,
+      title: title ?? this.title,
+      poster: poster ?? this.poster,
+      backdrop: backdrop ?? this.backdrop,
+      type: type ?? this.type,
+      episodeTitle: episodeTitle ?? this.episodeTitle,
+      seasonNumber: seasonNumber ?? this.seasonNumber,
+      episodeNumber: episodeNumber ?? this.episodeNumber,
+      position: position ?? this.position,
+      duration: duration ?? this.duration,
+      lastWatched: lastWatched ?? this.lastWatched,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'title': title,
+        'poster': poster,
+        'backdrop': backdrop,
+        'type': type,
+        'episodeTitle': episodeTitle,
+        'seasonNumber': seasonNumber,
+        'episodeNumber': episodeNumber,
+        'positionMs': position.inMilliseconds,
+        'durationMs': duration.inMilliseconds,
+        'lastWatched': lastWatched.toIso8601String(),
+      };
+
+  factory PlaybackHistoryItem.fromJson(Map<String, dynamic> json) {
+    return PlaybackHistoryItem(
+      id: json['id'] as String? ?? '',
+      title: json['title'] as String? ?? 'Unknown',
+      poster: json['poster'] as String?,
+      backdrop: json['backdrop'] as String?,
+      type: json['type'] as String? ?? 'movie',
+      episodeTitle: json['episodeTitle'] as String?,
+      seasonNumber: json['seasonNumber'] as int?,
+      episodeNumber: json['episodeNumber'] as int?,
+      position: Duration(milliseconds: json['positionMs'] as int? ?? 0),
+      duration: Duration(milliseconds: json['durationMs'] as int? ?? 0),
+      lastWatched: json['lastWatched'] != null
+          ? DateTime.tryParse(json['lastWatched'] as String) ?? DateTime.now()
+          : DateTime.now(),
+    );
+  }
+}

--- a/lib/pages/anime/anime_page.dart
+++ b/lib/pages/anime/anime_page.dart
@@ -9,6 +9,7 @@ import '../../services/anime/anime_library_service.dart';
 import '../../services/glass_settings.dart';
 import '../../utils/route_transitions.dart';
 import '../../widgets/anime/anime_slider_section.dart';
+import '../../widgets/common/app_dock.dart';
 import '../../widgets/common/liquid_dock.dart';
 import '../collection/collection_page.dart';
 import '../search/search_page.dart';
@@ -310,74 +311,7 @@ class _AnimePageState extends State<AnimePage> {
       ),
 
       // Liquid Dock Navbar (Home Page Style)
-      Positioned(
-        bottom: 24,
-        left: 0,
-        right: 0,
-        child: Center(
-          child: LiquidDock(
-            items: [
-              DockItem(
-                icon: Icons.movie_filter_rounded,
-                label: 'Media',
-                onTap: () => Navigator.pop(context),
-              ),
-              DockItem(
-                icon: Icons.auto_stories_rounded,
-                label: 'Manga',
-                onTap: () {
-                  Navigator.pushReplacement(
-                    context,
-                    LiquidRevealRoute(
-                      page: const MangaPage(),
-                      tapPosition: null,
-                    ),
-                  );
-                },
-              ),
-              DockItem(
-                icon: Icons.headphones_rounded,
-                label: 'Audiobooks',
-                onTap: () {
-                  Navigator.pushReplacement(
-                    context,
-                    LiquidRevealRoute(
-                      page: const AudiobooksPage(),
-                      tapPosition: null,
-                    ),
-                  );
-                },
-              ),
-              DockItem(
-                icon: Icons.music_note_rounded,
-                label: 'Music',
-                onTap: () {
-                  Navigator.pushReplacement(
-                    context,
-                    LiquidRevealRoute(
-                      page: const MusicPage(),
-                      tapPosition: null,
-                    ),
-                  );
-                },
-              ),
-              DockItem(
-                icon: Icons.video_library_rounded,
-                label: 'Collection',
-                onTap: () {
-                  Navigator.pushReplacement(
-                    context,
-                    LiquidRevealRoute(
-                      page: const CollectionPage(),
-                      tapPosition: null,
-                    ),
-                  );
-                },
-              ),
-            ],
-          ),
-        ),
-      ),
+      const AppDock(currentHub: AppHub.media),
 
       // Anime Details Modal Popup
       if (_activeDetailsModal != null)

--- a/lib/pages/anime/anime_page.dart
+++ b/lib/pages/anime/anime_page.dart
@@ -10,10 +10,7 @@ import '../../services/glass_settings.dart';
 import '../../utils/route_transitions.dart';
 import '../../widgets/anime/anime_slider_section.dart';
 import '../../widgets/common/liquid_dock.dart';
-import '../audiobooks/audiobooks_page.dart';
-import '../manga/manga_page.dart';
-import '../music/music_page.dart';
-import '../my_list/my_list_page.dart';
+import '../collection/collection_page.dart';
 import '../search/search_page.dart';
 import '../settings/settings_page.dart';
 import 'anime_details_modal.dart';
@@ -321,8 +318,8 @@ class _AnimePageState extends State<AnimePage> {
           child: LiquidDock(
             items: [
               DockItem(
-                icon: Icons.home_rounded,
-                label: 'Home',
+                icon: Icons.movie_filter_rounded,
+                label: 'Media',
                 onTap: () => Navigator.pop(context),
               ),
               DockItem(
@@ -365,42 +362,17 @@ class _AnimePageState extends State<AnimePage> {
                 },
               ),
               DockItem(
-                icon: Icons.animation_rounded,
-                label: 'Anime',
-                onTap: () {},
-              ),
-              DockItem(
-                icon: Icons.extension_rounded,
-                label: 'Addons',
-                onTap: () {},
-              ),
-              DockItem(
-                icon: Icons.download_rounded,
-                label: 'Downloads',
-                onTap: () {},
-              ),
-              DockItem(
-                icon: Icons.favorite_rounded,
-                label: 'My List',
+                icon: Icons.video_library_rounded,
+                label: 'Collection',
                 onTap: () {
                   Navigator.pushReplacement(
                     context,
                     LiquidRevealRoute(
-                      page: const MyListPage(),
+                      page: const CollectionPage(),
                       tapPosition: null,
                     ),
                   );
                 },
-              ),
-              DockItem(
-                icon: Icons.settings_rounded,
-                label: 'Settings',
-                onTap: () => _navigateToSettings(null),
-              ),
-              DockItem(
-                icon: Icons.search_rounded,
-                label: 'Search',
-                onTap: () => _navigateToSearch(null),
               ),
             ],
           ),

--- a/lib/pages/anime/anime_page.dart
+++ b/lib/pages/anime/anime_page.dart
@@ -311,7 +311,7 @@ class _AnimePageState extends State<AnimePage> {
       ),
 
       // Liquid Dock Navbar (Home Page Style)
-      const AppDock(currentHub: AppHub.media),
+      const AppDock(currentHub: AppHub.anime),
 
       // Anime Details Modal Popup
       if (_activeDetailsModal != null)

--- a/lib/pages/audiobooks/audiobooks_page.dart
+++ b/lib/pages/audiobooks/audiobooks_page.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import '../../models/audiobook/audiobook_model.dart';
 import '../../services/audiobook/audiobook_progress_service.dart';
 import '../../services/audiobook/audiobook_scraper_service.dart';
+import '../../widgets/common/app_dock.dart';
 import 'audiobook_detail_page.dart';
 import 'audiobook_player_screen.dart';
 import 'audiobook_route_transitions.dart';
@@ -329,6 +330,9 @@ class _AudiobooksPageState extends State<AudiobooksPage> {
                 ),
             ],
           ),
+
+          // Persistent Bottom Navigation Dock
+          const AppDock(currentHub: AppHub.audiobooks),
         ],
       ),
     );

--- a/lib/pages/collection/collection_page.dart
+++ b/lib/pages/collection/collection_page.dart
@@ -186,7 +186,7 @@ class _CollectionPageState extends State<CollectionPage>
                             color: Color(0xFFED1C24),
                             size: 22,
                           ),
-                    onPressed: syncing ? null : () => TraktSyncService.syncAll(),
+                    onPressed: syncing ? null : () => TraktSyncService.manualSync(),
                   );
                 },
               );

--- a/lib/pages/collection/collection_page.dart
+++ b/lib/pages/collection/collection_page.dart
@@ -397,7 +397,7 @@ class _CollectionPageState extends State<CollectionPage>
         }
 
         return ListView.separated(
-          padding: const EdgeInsets.all(16),
+          padding: const EdgeInsets.fromLTRB(16, 16, 16, 100),
           itemCount: downloads.length,
           separatorBuilder: (_, __) => const SizedBox(height: 12),
           itemBuilder: (context, index) {
@@ -600,7 +600,7 @@ class _CollectionPageState extends State<CollectionPage>
 
   Widget _buildGrid(List<MyListItem> items) {
     return GridView.builder(
-      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 100),
       gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
         crossAxisCount: _getCrossAxisCount(context),
         childAspectRatio: 0.65,

--- a/lib/pages/collection/collection_page.dart
+++ b/lib/pages/collection/collection_page.dart
@@ -1,0 +1,585 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+
+import '../../models/download/download_item.dart';
+import '../../models/movie/movie.dart';
+import '../../models/my_list/my_list_item.dart';
+import '../../services/download/download_service.dart';
+import '../../services/my_list/my_list_service.dart';
+import '../../services/trakt/trakt_auth_service.dart';
+import '../../services/trakt/trakt_sync_service.dart';
+import '../../utils/route_transitions.dart';
+import '../details/details_page.dart';
+
+class CollectionPage extends StatefulWidget {
+  final int initialTabIndex;
+
+  const CollectionPage({
+    super.key,
+    this.initialTabIndex = 0,
+  });
+
+  @override
+  State<CollectionPage> createState() => _CollectionPageState();
+}
+
+class _CollectionPageState extends State<CollectionPage>
+    with SingleTickerProviderStateMixin {
+  late TabController _tabController;
+  final TextEditingController _searchController = TextEditingController();
+
+  String _filterType = 'all'; // 'all', 'movie', 'series', 'anime'
+  String _sortBy = 'recent'; // 'recent', 'title', 'year'
+  String _searchQuery = '';
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(
+      length: 3,
+      vsync: this,
+      initialIndex: widget.initialTabIndex,
+    );
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  List<MyListItem> _getFilteredAndSortedItems(List<MyListItem> allItems) {
+    var filtered = allItems.where((item) {
+      if (_filterType == 'movie' && item.type != 'movie') return false;
+      if (_filterType == 'series' && item.type != 'series' && item.type != 'anime') return false;
+      if (_filterType == 'anime' && item.type != 'anime') return false;
+
+      if (_searchQuery.trim().isNotEmpty) {
+        final query = _searchQuery.toLowerCase().trim();
+        final title = item.title.toLowerCase();
+        if (!title.contains(query)) return false;
+      }
+      return true;
+    }).toList();
+
+    switch (_sortBy) {
+      case 'recent':
+        filtered.sort((a, b) => b.addedAt.compareTo(a.addedAt));
+        break;
+      case 'title':
+        filtered.sort((a, b) => a.title.toLowerCase().compareTo(b.title.toLowerCase()));
+        break;
+      case 'year':
+        filtered.sort((a, b) => (b.year ?? 0).compareTo(a.year ?? 0));
+        break;
+    }
+    return filtered;
+  }
+
+  int _getCrossAxisCount(BuildContext context) {
+    final width = MediaQuery.of(context).size.width;
+    if (width < 600) return 2;
+    if (width < 900) return 3;
+    if (width < 1200) return 4;
+    return 5;
+  }
+
+  void _navigateToDetail(MyListItem item) {
+    final effectiveId = item.imdbId ??
+        (item.tmdbId != null ? 'tmdb:${item.tmdbId}' : null) ??
+        item.traktId?.toString() ??
+        '';
+
+    final movie = Movie(
+      id: effectiveId,
+      name: item.title,
+      poster: item.poster,
+      year: item.year?.toString(),
+      type: item.type,
+      addonBaseUrl: 'https://v3-cinemeta.strem.io',
+    );
+
+    Navigator.push(
+      context,
+      LiquidRevealRoute(
+        page: DetailsPage(movie: movie),
+        tapPosition: null,
+      ),
+    );
+  }
+
+  Future<void> _confirmRemove(MyListItem item) async {
+    final confirm = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        backgroundColor: const Color(0xFF151822),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+        title: const Text('Remove from Collection?',
+            style: TextStyle(fontWeight: FontWeight.w800, color: Colors.white)),
+        content: Text(
+          'Remove "${item.title}" from your collection?',
+          style: TextStyle(color: Colors.white.withValues(alpha: 0.7)),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: Text('Cancel',
+                style: TextStyle(color: Colors.white.withValues(alpha: 0.6))),
+          ),
+          ElevatedButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            style: ElevatedButton.styleFrom(
+              backgroundColor: const Color(0xFFE50914),
+              shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
+            ),
+            child: const Text('Remove', style: TextStyle(color: Colors.white, fontWeight: FontWeight.bold)),
+          ),
+        ],
+      ),
+    );
+
+    if (confirm == true) {
+      MyListService.remove(item);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final traktAuth = TraktAuthService();
+
+    return Scaffold(
+      backgroundColor: const Color(0xFF080A0F),
+      appBar: AppBar(
+        backgroundColor: const Color(0xFF0D1017),
+        surfaceTintColor: Colors.transparent,
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back_ios_rounded, size: 20),
+          onPressed: () => Navigator.pop(context),
+        ),
+        title: const Text(
+          'Collection',
+          style: TextStyle(fontWeight: FontWeight.w800, fontSize: 20),
+        ),
+        actions: [
+          ValueListenableBuilder<bool>(
+            valueListenable: traktAuth.isLoggedIn,
+            builder: (context, loggedIn, _) {
+              if (!loggedIn) return const SizedBox.shrink();
+              return ValueListenableBuilder<bool>(
+                valueListenable: TraktSyncService.isSyncing,
+                builder: (context, syncing, _) {
+                  return IconButton(
+                    tooltip: 'Sync with Trakt',
+                    icon: syncing
+                        ? const SizedBox(
+                            width: 18,
+                            height: 18,
+                            child: CircularProgressIndicator(
+                              strokeWidth: 2,
+                              color: Color(0xFFED1C24),
+                            ),
+                          )
+                        : const Icon(
+                            Icons.sync_rounded,
+                            color: Color(0xFFED1C24),
+                            size: 22,
+                          ),
+                    onPressed: syncing ? null : () => TraktSyncService.syncAll(),
+                  );
+                },
+              );
+            },
+          ),
+          const SizedBox(width: 8),
+        ],
+        bottom: TabBar(
+          controller: _tabController,
+          indicatorColor: const Color(0xFF7C5CFF),
+          indicatorWeight: 3,
+          labelColor: Colors.white,
+          unselectedLabelColor: Colors.white54,
+          labelStyle: const TextStyle(fontWeight: FontWeight.w700, fontSize: 14),
+          tabs: const [
+            Tab(icon: Icon(Icons.favorite_rounded, size: 18), text: 'My List'),
+            Tab(icon: Icon(Icons.bookmark_rounded, size: 18), text: 'Watchlist'),
+            Tab(icon: Icon(Icons.download_rounded, size: 18), text: 'Downloads'),
+          ],
+        ),
+      ),
+      body: TabBarView(
+        controller: _tabController,
+        children: [
+          _buildMyListTab(),
+          _buildWatchlistTab(),
+          _buildDownloadsTab(),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildMyListTab() {
+    return ValueListenableBuilder<List<MyListItem>>(
+      valueListenable: MyListService.items,
+      builder: (context, allItems, _) {
+        final items = _getFilteredAndSortedItems(allItems);
+
+        return Column(
+          children: [
+            _buildFilterAndSearchBar(allItems.length),
+            Expanded(
+              child: items.isEmpty
+                  ? _buildEmptyState(
+                      icon: Icons.video_library_rounded,
+                      title: allItems.isEmpty
+                          ? 'Your list is empty'
+                          : 'No matching items',
+                      subtitle: allItems.isEmpty
+                          ? 'Add movies, series or anime to access them quickly.'
+                          : 'Try adjusting your search or filters.',
+                    )
+                  : _buildGrid(items),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  Widget _buildWatchlistTab() {
+    return ValueListenableBuilder<List<MyListItem>>(
+      valueListenable: MyListService.items,
+      builder: (context, allItems, _) {
+        final watchlist = allItems.where((i) => i.isWatchlist).toList();
+        final items = _getFilteredAndSortedItems(watchlist);
+
+        return Column(
+          children: [
+            _buildFilterAndSearchBar(watchlist.length),
+            Expanded(
+              child: items.isEmpty
+                  ? _buildEmptyState(
+                      icon: Icons.bookmark_border_rounded,
+                      title: watchlist.isEmpty
+                          ? 'Watchlist is empty'
+                          : 'No matching items',
+                      subtitle: watchlist.isEmpty
+                          ? 'Save movies or series to watch later.'
+                          : 'Try adjusting your search or filters.',
+                    )
+                  : _buildGrid(items),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  Widget _buildDownloadsTab() {
+    return ValueListenableBuilder<List<DownloadItem>>(
+      valueListenable: DownloadService.downloads,
+      builder: (context, downloads, _) {
+        if (downloads.isEmpty) {
+          return _buildEmptyState(
+            icon: Icons.download_done_rounded,
+            title: 'No Downloads',
+            subtitle: 'Downloaded movies and episodes will appear here for offline viewing.',
+          );
+        }
+
+        return ListView.separated(
+          padding: const EdgeInsets.all(16),
+          itemCount: downloads.length,
+          separatorBuilder: (_, __) => const SizedBox(height: 12),
+          itemBuilder: (context, index) {
+            final item = downloads[index];
+            return Container(
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: const Color(0xFF12151E),
+                borderRadius: BorderRadius.circular(14),
+                border: Border.all(color: Colors.white.withValues(alpha: 0.08)),
+              ),
+              child: Row(
+                children: [
+                  ClipRRect(
+                    borderRadius: BorderRadius.circular(8),
+                    child: item.poster != null
+                        ? CachedNetworkImage(
+                            imageUrl: item.poster!,
+                            width: 50,
+                            height: 75,
+                            fit: BoxFit.cover,
+                            errorWidget: (_, __, ___) => Container(
+                              width: 50,
+                              height: 75,
+                              color: Colors.white10,
+                              child: const Icon(Icons.movie_rounded, color: Colors.white30),
+                            ),
+                          )
+                        : Container(
+                            width: 50,
+                            height: 75,
+                            color: Colors.white10,
+                            child: const Icon(Icons.movie_rounded, color: Colors.white30),
+                          ),
+                  ),
+                  const SizedBox(width: 14),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          item.title,
+                          style: const TextStyle(fontWeight: FontWeight.w700, fontSize: 15),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                        if (item.episodeTitle != null) ...[
+                          const SizedBox(height: 2),
+                          Text(
+                            item.episodeTitle!,
+                            style: const TextStyle(color: Colors.white54, fontSize: 12),
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ],
+                        const SizedBox(height: 8),
+                        LinearProgressIndicator(
+                          value: item.progress > 0 ? item.progress : null,
+                          backgroundColor: Colors.white10,
+                          valueColor: const AlwaysStoppedAnimation<Color>(Color(0xFF7C5CFF)),
+                          borderRadius: BorderRadius.circular(4),
+                        ),
+                        const SizedBox(height: 4),
+                        Text(
+                          '${item.status.name.toUpperCase()} • ${(item.progress * 100).toStringAsFixed(0)}%',
+                          style: const TextStyle(color: Colors.white38, fontSize: 11),
+                        ),
+                      ],
+                    ),
+                  ),
+                  IconButton(
+                    icon: const Icon(Icons.delete_outline_rounded, color: Colors.redAccent),
+                    onPressed: () => DownloadService.removeDownload(item.id),
+                  ),
+                ],
+              ),
+            );
+          },
+        );
+      },
+    );
+  }
+
+  Widget _buildFilterAndSearchBar(int totalCount) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      child: Column(
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: Container(
+                  height: 40,
+                  decoration: BoxDecoration(
+                    color: const Color(0xFF141824),
+                    borderRadius: BorderRadius.circular(10),
+                    border: Border.all(color: Colors.white.withValues(alpha: 0.08)),
+                  ),
+                  padding: const EdgeInsets.symmetric(horizontal: 12),
+                  child: Row(
+                    children: [
+                      const Icon(Icons.search_rounded, size: 18, color: Colors.white54),
+                      const SizedBox(width: 8),
+                      Expanded(
+                        child: TextField(
+                          controller: _searchController,
+                          onChanged: (val) => setState(() => _searchQuery = val),
+                          style: const TextStyle(fontSize: 13, color: Colors.white),
+                          decoration: const InputDecoration(
+                            hintText: 'Search collection...',
+                            hintStyle: TextStyle(color: Colors.white38, fontSize: 13),
+                            border: InputBorder.none,
+                            isDense: true,
+                          ),
+                        ),
+                      ),
+                      if (_searchQuery.isNotEmpty)
+                        GestureDetector(
+                          onTap: () {
+                            _searchController.clear();
+                            setState(() => _searchQuery = '');
+                          },
+                          child: const Icon(Icons.close_rounded, size: 16, color: Colors.white54),
+                        ),
+                    ],
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 10),
+          Row(
+            children: [
+              _buildChoiceChip('All', 'all'),
+              const SizedBox(width: 6),
+              _buildChoiceChip('Movies', 'movie'),
+              const SizedBox(width: 6),
+              _buildChoiceChip('Series', 'series'),
+              const SizedBox(width: 6),
+              _buildChoiceChip('Anime', 'anime'),
+              const Spacer(),
+              PopupMenuButton<String>(
+                initialValue: _sortBy,
+                tooltip: 'Sort by',
+                onSelected: (val) => setState(() => _sortBy = val),
+                color: const Color(0xFF151822),
+                child: Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+                  decoration: BoxDecoration(
+                    color: const Color(0xFF141824),
+                    borderRadius: BorderRadius.circular(8),
+                    border: Border.all(color: Colors.white.withValues(alpha: 0.08)),
+                  ),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      const Icon(Icons.sort_rounded, size: 14, color: Colors.white70),
+                      const SizedBox(width: 4),
+                      Text(
+                        _sortBy.toUpperCase(),
+                        style: const TextStyle(fontSize: 11, fontWeight: FontWeight.bold, color: Colors.white70),
+                      ),
+                    ],
+                  ),
+                ),
+                itemBuilder: (context) => [
+                  const PopupMenuItem(value: 'recent', child: Text('Recently Added')),
+                  const PopupMenuItem(value: 'title', child: Text('Title (A-Z)')),
+                  const PopupMenuItem(value: 'year', child: Text('Release Year')),
+                ],
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildChoiceChip(String label, String value) {
+    final isSelected = _filterType == value;
+    return GestureDetector(
+      onTap: () => setState(() => _filterType = value),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+        decoration: BoxDecoration(
+          color: isSelected ? const Color(0xFF7C5CFF) : const Color(0xFF141824),
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Text(
+          label,
+          style: TextStyle(
+            fontSize: 11.5,
+            fontWeight: isSelected ? FontWeight.w700 : FontWeight.w500,
+            color: isSelected ? Colors.white : Colors.white60,
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildGrid(List<MyListItem> items) {
+    return GridView.builder(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+        crossAxisCount: _getCrossAxisCount(context),
+        childAspectRatio: 0.65,
+        crossAxisSpacing: 12,
+        mainAxisSpacing: 12,
+      ),
+      itemCount: items.length,
+      itemBuilder: (context, index) {
+        final item = items[index];
+        return GestureDetector(
+          onTap: () => _navigateToDetail(item),
+          onLongPress: () => _confirmRemove(item),
+          child: ClipRRect(
+            borderRadius: BorderRadius.circular(12),
+            child: Stack(
+              fit: StackFit.expand,
+              children: [
+                if (item.poster != null && item.poster!.isNotEmpty)
+                  CachedNetworkImage(
+                    imageUrl: item.poster!,
+                    fit: BoxFit.cover,
+                    placeholder: (_, __) => Container(color: const Color(0xFF141824)),
+                    errorWidget: (_, __, ___) => Container(
+                      color: const Color(0xFF141824),
+                      child: const Icon(Icons.movie_rounded, color: Colors.white24),
+                    ),
+                  )
+                else
+                  Container(
+                    color: const Color(0xFF141824),
+                    child: const Icon(Icons.movie_rounded, color: Colors.white24),
+                  ),
+                Positioned(
+                  bottom: 0,
+                  left: 0,
+                  right: 0,
+                  child: Container(
+                    padding: const EdgeInsets.all(8),
+                    decoration: const BoxDecoration(
+                      gradient: LinearGradient(
+                        begin: Alignment.bottomCenter,
+                        end: Alignment.topCenter,
+                        colors: [Colors.black87, Colors.transparent],
+                      ),
+                    ),
+                    child: Text(
+                      item.title,
+                      style: const TextStyle(
+                        fontSize: 12,
+                        fontWeight: FontWeight.w700,
+                        color: Colors.white,
+                      ),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildEmptyState({
+    required IconData icon,
+    required String title,
+    required String subtitle,
+  }) {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 48, color: Colors.white24),
+          const SizedBox(height: 12),
+          Text(title, style: const TextStyle(fontWeight: FontWeight.w800, fontSize: 16, color: Colors.white)),
+          const SizedBox(height: 6),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 32),
+            child: Text(
+              subtitle,
+              textAlign: TextAlign.center,
+              style: const TextStyle(fontSize: 13, color: Colors.white54),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/pages/collection/collection_page.dart
+++ b/lib/pages/collection/collection_page.dart
@@ -9,6 +9,7 @@ import '../../services/my_list/my_list_service.dart';
 import '../../services/trakt/trakt_auth_service.dart';
 import '../../services/trakt/trakt_sync_service.dart';
 import '../../utils/route_transitions.dart';
+import '../../widgets/common/app_dock.dart';
 import '../details/details_page.dart';
 
 class CollectionPage extends StatefulWidget {
@@ -207,12 +208,17 @@ class _CollectionPageState extends State<CollectionPage>
           ],
         ),
       ),
-      body: TabBarView(
-        controller: _tabController,
+      body: Stack(
         children: [
-          _buildMyListTab(),
-          _buildWatchlistTab(),
-          _buildDownloadsTab(),
+          TabBarView(
+            controller: _tabController,
+            children: [
+              _buildMyListTab(),
+              _buildWatchlistTab(),
+              _buildDownloadsTab(),
+            ],
+          ),
+          const AppDock(currentHub: AppHub.collection),
         ],
       ),
     );

--- a/lib/pages/collection/collection_page.dart
+++ b/lib/pages/collection/collection_page.dart
@@ -4,8 +4,10 @@ import 'package:flutter/material.dart';
 import '../../models/download/download_item.dart';
 import '../../models/movie/movie.dart';
 import '../../models/my_list/my_list_item.dart';
+import '../../models/playback/playback_history_item.dart';
 import '../../services/download/download_service.dart';
 import '../../services/my_list/my_list_service.dart';
+import '../../services/playback/playback_history_service.dart';
 import '../../services/trakt/trakt_auth_service.dart';
 import '../../services/trakt/trakt_sync_service.dart';
 import '../../utils/route_transitions.dart';
@@ -37,7 +39,7 @@ class _CollectionPageState extends State<CollectionPage>
   void initState() {
     super.initState();
     _tabController = TabController(
-      length: 3,
+      length: 4,
       vsync: this,
       initialIndex: widget.initialTabIndex,
     );
@@ -200,11 +202,12 @@ class _CollectionPageState extends State<CollectionPage>
           indicatorWeight: 3,
           labelColor: Colors.white,
           unselectedLabelColor: Colors.white54,
-          labelStyle: const TextStyle(fontWeight: FontWeight.w700, fontSize: 14),
+          labelStyle: const TextStyle(fontWeight: FontWeight.w700, fontSize: 13),
           tabs: const [
-            Tab(icon: Icon(Icons.favorite_rounded, size: 18), text: 'My List'),
-            Tab(icon: Icon(Icons.bookmark_rounded, size: 18), text: 'Watchlist'),
-            Tab(icon: Icon(Icons.download_rounded, size: 18), text: 'Downloads'),
+            Tab(icon: Icon(Icons.favorite_rounded, size: 17), text: 'My List'),
+            Tab(icon: Icon(Icons.bookmark_rounded, size: 17), text: 'Watchlist'),
+            Tab(icon: Icon(Icons.history_rounded, size: 17), text: 'History'),
+            Tab(icon: Icon(Icons.download_rounded, size: 17), text: 'Downloads'),
           ],
         ),
       ),
@@ -215,6 +218,7 @@ class _CollectionPageState extends State<CollectionPage>
             children: [
               _buildMyListTab(),
               _buildWatchlistTab(),
+              _buildHistoryTab(),
               _buildDownloadsTab(),
             ],
           ),
@@ -276,6 +280,105 @@ class _CollectionPageState extends State<CollectionPage>
                   : _buildGrid(items),
             ),
           ],
+        );
+      },
+    );
+  }
+
+  Widget _buildHistoryTab() {
+    return ValueListenableBuilder<List<PlaybackHistoryItem>>(
+      valueListenable: PlaybackHistoryService.history,
+      builder: (context, historyItems, _) {
+        if (historyItems.isEmpty) {
+          return _buildEmptyState(
+            icon: Icons.history_rounded,
+            title: 'No Playback History',
+            subtitle: 'Movies and episodes you watch will appear here so you can continue where you left off.',
+          );
+        }
+
+        return ListView.separated(
+          padding: const EdgeInsets.fromLTRB(16, 16, 16, 100),
+          itemCount: historyItems.length,
+          separatorBuilder: (_, __) => const SizedBox(height: 12),
+          itemBuilder: (context, index) {
+            final item = historyItems[index];
+            final progressPercent = (item.progressPercentage * 100).toInt();
+
+            return Container(
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: const Color(0xFF12151E),
+                borderRadius: BorderRadius.circular(14),
+                border: Border.all(color: Colors.white.withValues(alpha: 0.08)),
+              ),
+              child: Row(
+                children: [
+                  ClipRRect(
+                    borderRadius: BorderRadius.circular(8),
+                    child: item.poster != null
+                        ? CachedNetworkImage(
+                            imageUrl: item.poster!,
+                            width: 50,
+                            height: 75,
+                            fit: BoxFit.cover,
+                            errorWidget: (_, __, ___) => Container(
+                              width: 50,
+                              height: 75,
+                              color: Colors.white10,
+                              child: const Icon(Icons.movie_rounded, color: Colors.white30),
+                            ),
+                          )
+                        : Container(
+                            width: 50,
+                            height: 75,
+                            color: Colors.white10,
+                            child: const Icon(Icons.movie_rounded, color: Colors.white30),
+                          ),
+                  ),
+                  const SizedBox(width: 14),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          item.title,
+                          style: const TextStyle(fontWeight: FontWeight.w700, fontSize: 15),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                        if (item.episodeTitle != null) ...[
+                          const SizedBox(height: 2),
+                          Text(
+                            'S${item.seasonNumber ?? 1} E${item.episodeNumber ?? 1} • ${item.episodeTitle!}',
+                            style: const TextStyle(color: Colors.white54, fontSize: 12),
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ],
+                        const SizedBox(height: 8),
+                        LinearProgressIndicator(
+                          value: item.progressPercentage,
+                          backgroundColor: Colors.white10,
+                          valueColor: const AlwaysStoppedAnimation<Color>(Color(0xFF7C5CFF)),
+                          borderRadius: BorderRadius.circular(4),
+                        ),
+                        const SizedBox(height: 4),
+                        Text(
+                          '$progressPercent% completed',
+                          style: const TextStyle(color: Colors.white38, fontSize: 11),
+                        ),
+                      ],
+                    ),
+                  ),
+                  IconButton(
+                    icon: const Icon(Icons.close_rounded, color: Colors.white38, size: 20),
+                    onPressed: () => PlaybackHistoryService.removeProgress(item.id),
+                  ),
+                ],
+              ),
+            );
+          },
         );
       },
     );

--- a/lib/pages/details/details_page.dart
+++ b/lib/pages/details/details_page.dart
@@ -3,6 +3,7 @@ import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
+import '../../models/movie/cast_member.dart';
 import '../../models/movie/movie.dart';
 import '../../models/movie/link.dart';
 import '../../models/movie/video.dart';
@@ -452,8 +453,12 @@ class _DetailsPageState extends State<DetailsPage> with SingleTickerProviderStat
                           SizedBox(height: heroHeight - overlap),
                           isDesktop ? _buildDesktopLayout(meta, posterUrl) : _buildMobileLayout(meta, posterUrl),
                           const SizedBox(height: _Space.xl),
-                          if (meta.cast.isNotEmpty) ...[
-                            _buildCastRow(meta.cast),
+                          if (meta.castMembers.isNotEmpty || meta.cast.isNotEmpty) ...[
+                            _buildCastRow(meta),
+                            const SizedBox(height: _Space.xl),
+                          ],
+                          if (meta.directorsList.isNotEmpty || meta.director.isNotEmpty) ...[
+                            _buildDirectorRow(meta),
                             const SizedBox(height: _Space.xl),
                           ],
                           if ((widget.movie.type == 'series' || widget.movie.type == 'anime') && meta.videos.isNotEmpty) ...[
@@ -1038,7 +1043,11 @@ class _DetailsPageState extends State<DetailsPage> with SingleTickerProviderStat
     );
   }
 
-  Widget _buildCastRow(List<String> cast) {
+  Widget _buildCastRow(MovieDetail meta) {
+    final List<CastMember> members = meta.castMembers.isNotEmpty
+        ? meta.castMembers
+        : meta.cast.map((c) => CastMember(name: c)).toList();
+
     return MouseRegion(
       onEnter: (_) => setState(() => _isHoveringCast = true),
       onExit: (_) => setState(() => _isHoveringCast = false),
@@ -1047,7 +1056,7 @@ class _DetailsPageState extends State<DetailsPage> with SingleTickerProviderStat
         children: [
           _buildSectionHeader('Cast'),
           SizedBox(
-            height: 132,
+            height: 148,
             child: Stack(
               clipBehavior: Clip.none,
               children: [
@@ -1056,17 +1065,18 @@ class _DetailsPageState extends State<DetailsPage> with SingleTickerProviderStat
                   controller: _castScrollController,
                   scrollDirection: Axis.horizontal,
                   physics: const BouncingScrollPhysics(),
-                  itemCount: cast.length,
+                  itemCount: members.length,
                   separatorBuilder: (_, __) => const SizedBox(width: _Space.lg),
                   itemBuilder: (context, index) {
-                    final name = cast[index];
+                    final member = members[index];
+                    final name = member.name;
                     final initials = name.isNotEmpty
                         ? name.trim().split(' ').map((e) => e.isNotEmpty ? e[0] : '').take(2).join('').toUpperCase()
                         : '?';
                     final pair = _Palette.avatarPairs[name.hashCode.abs() % _Palette.avatarPairs.length];
 
                     return SizedBox(
-                      width: 84,
+                      width: 88,
                       child: Column(
                         children: [
                           Builder(
@@ -1090,24 +1100,58 @@ class _DetailsPageState extends State<DetailsPage> with SingleTickerProviderStat
                                     height: 76,
                                     decoration: BoxDecoration(
                                       shape: BoxShape.circle,
-                                      gradient: LinearGradient(begin: Alignment.topLeft, end: Alignment.bottomRight, colors: pair),
+                                      gradient: member.profileUrl == null
+                                          ? LinearGradient(begin: Alignment.topLeft, end: Alignment.bottomRight, colors: pair)
+                                          : null,
                                       border: Border.all(color: Colors.white.withOpacity(0.1), width: 1.5),
                                     ),
+                                    clipBehavior: Clip.antiAlias,
                                     alignment: Alignment.center,
-                                    child: Text(initials, style: const TextStyle(color: Colors.white, fontSize: 24, fontWeight: FontWeight.bold)),
+                                    child: member.profileUrl != null
+                                        ? CachedNetworkImage(
+                                            imageUrl: member.profileUrl!,
+                                            width: 76,
+                                            height: 76,
+                                            fit: BoxFit.cover,
+                                            placeholder: (_, __) => Container(
+                                              decoration: BoxDecoration(
+                                                gradient: LinearGradient(begin: Alignment.topLeft, end: Alignment.bottomRight, colors: pair),
+                                              ),
+                                              alignment: Alignment.center,
+                                              child: Text(initials, style: const TextStyle(color: Colors.white, fontSize: 24, fontWeight: FontWeight.bold)),
+                                            ),
+                                            errorWidget: (_, __, ___) => Container(
+                                              decoration: BoxDecoration(
+                                                gradient: LinearGradient(begin: Alignment.topLeft, end: Alignment.bottomRight, colors: pair),
+                                              ),
+                                              alignment: Alignment.center,
+                                              child: Text(initials, style: const TextStyle(color: Colors.white, fontSize: 24, fontWeight: FontWeight.bold)),
+                                            ),
+                                          )
+                                        : Text(initials, style: const TextStyle(color: Colors.white, fontSize: 24, fontWeight: FontWeight.bold)),
                                   ),
                                 ),
                               );
                             }
                           ),
-                          const SizedBox(height: 8),
+                          const SizedBox(height: 6),
                           Text(
                             name,
                             textAlign: TextAlign.center,
-                            maxLines: 2,
+                            maxLines: 1,
                             overflow: TextOverflow.ellipsis,
-                            style: const TextStyle(color: Colors.white70, fontSize: 12, height: 1.2),
+                            style: const TextStyle(color: Colors.white, fontSize: 12, fontWeight: FontWeight.w600, height: 1.2),
                           ),
+                          if (member.character != null && member.character!.isNotEmpty) ...[
+                            const SizedBox(height: 2),
+                            Text(
+                              member.character!,
+                              textAlign: TextAlign.center,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              style: const TextStyle(color: Colors.white54, fontSize: 10.5, height: 1.1),
+                            ),
+                          ],
                         ],
                       ),
                     );
@@ -1130,6 +1174,116 @@ class _DetailsPageState extends State<DetailsPage> with SingleTickerProviderStat
           ),
         ],
       ),
+    );
+  }
+
+  Widget _buildDirectorRow(MovieDetail meta) {
+    final List<CrewMember> directors = meta.directorsList.isNotEmpty
+        ? meta.directorsList
+        : meta.director.map((d) => CrewMember(name: d, job: 'Director')).toList();
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _buildSectionHeader('Direction'),
+        SizedBox(
+          height: 132,
+          child: ListView.separated(
+            clipBehavior: Clip.none,
+            scrollDirection: Axis.horizontal,
+            physics: const BouncingScrollPhysics(),
+            itemCount: directors.length,
+            separatorBuilder: (_, __) => const SizedBox(width: _Space.lg),
+            itemBuilder: (context, index) {
+              final director = directors[index];
+              final name = director.name;
+              final initials = name.isNotEmpty
+                  ? name.trim().split(' ').map((e) => e.isNotEmpty ? e[0] : '').take(2).join('').toUpperCase()
+                  : '?';
+              final pair = _Palette.avatarPairs[name.hashCode.abs() % _Palette.avatarPairs.length];
+
+              return SizedBox(
+                width: 88,
+                child: Column(
+                  children: [
+                    Builder(
+                      builder: (context) {
+                        Offset? lastTap;
+                        return GestureDetector(
+                          onTapDown: (d) => lastTap = d.globalPosition,
+                          child: _HoverButton(
+                            onTap: () {
+                              Navigator.push(
+                                context,
+                                LiquidRevealRoute(
+                                  page: DiscoverPage(query: name, isGenre: false),
+                                  tapPosition: lastTap,
+                                ),
+                              );
+                            },
+                            scaleAmount: 1.05,
+                            child: Container(
+                              width: 76,
+                              height: 76,
+                              decoration: BoxDecoration(
+                                shape: BoxShape.circle,
+                                gradient: director.profileUrl == null
+                                    ? LinearGradient(begin: Alignment.topLeft, end: Alignment.bottomRight, colors: pair)
+                                    : null,
+                                border: Border.all(color: Colors.white.withOpacity(0.1), width: 1.5),
+                              ),
+                              clipBehavior: Clip.antiAlias,
+                              alignment: Alignment.center,
+                              child: director.profileUrl != null
+                                  ? CachedNetworkImage(
+                                      imageUrl: director.profileUrl!,
+                                      width: 76,
+                                      height: 76,
+                                      fit: BoxFit.cover,
+                                      placeholder: (_, __) => Container(
+                                        decoration: BoxDecoration(
+                                          gradient: LinearGradient(begin: Alignment.topLeft, end: Alignment.bottomRight, colors: pair),
+                                        ),
+                                        alignment: Alignment.center,
+                                        child: Text(initials, style: const TextStyle(color: Colors.white, fontSize: 24, fontWeight: FontWeight.bold)),
+                                      ),
+                                      errorWidget: (_, __, ___) => Container(
+                                        decoration: BoxDecoration(
+                                          gradient: LinearGradient(begin: Alignment.topLeft, end: Alignment.bottomRight, colors: pair),
+                                        ),
+                                        alignment: Alignment.center,
+                                        child: Text(initials, style: const TextStyle(color: Colors.white, fontSize: 24, fontWeight: FontWeight.bold)),
+                                      ),
+                                    )
+                                  : Text(initials, style: const TextStyle(color: Colors.white, fontSize: 24, fontWeight: FontWeight.bold)),
+                            ),
+                          ),
+                        );
+                      }
+                    ),
+                    const SizedBox(height: 6),
+                    Text(
+                      name,
+                      textAlign: TextAlign.center,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: const TextStyle(color: Colors.white, fontSize: 12, fontWeight: FontWeight.w600, height: 1.2),
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      director.job,
+                      textAlign: TextAlign.center,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: const TextStyle(color: Colors.white54, fontSize: 10.5, height: 1.1),
+                    ),
+                  ],
+                ),
+              );
+            },
+          ),
+        ),
+      ],
     );
   }
 

--- a/lib/pages/details/details_page.dart
+++ b/lib/pages/details/details_page.dart
@@ -951,13 +951,13 @@ class _DetailsPageState extends State<DetailsPage> with SingleTickerProviderStat
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
                 Icon(
-                  inList ? Icons.favorite_rounded : Icons.favorite_border_rounded,
+                  inList ? Icons.bookmark_added_rounded : Icons.bookmark_add_outlined,
                   color: inList ? const Color(0xFF7C5CFF) : Colors.white,
                   size: 22,
                 ),
                 const SizedBox(width: 6),
                 Text(
-                  inList ? 'In Library' : 'Library',
+                  inList ? 'In Collection' : 'Add to Collection',
                   style: TextStyle(
                     color: inList ? const Color(0xFF7C5CFF) : Colors.white,
                     fontSize: 14,

--- a/lib/pages/home/home_page.dart
+++ b/lib/pages/home/home_page.dart
@@ -230,15 +230,6 @@ class _HomePageState extends State<HomePage> {
           topPadding: topPadding,
           onSearchTap: _navigateToSearch,
           onSettingsTap: _navigateToSettings,
-          onAnimeTap: (tapPosition) {
-            Navigator.push(
-              context,
-              LiquidRevealRoute(
-                page: const AnimePage(),
-                tapPosition: tapPosition,
-              ),
-            );
-          },
         ),
       ),
 
@@ -349,13 +340,11 @@ class _GlassAppBar extends StatelessWidget {
   final double topPadding;
   final void Function(Offset?) onSearchTap;
   final void Function(Offset?) onSettingsTap;
-  final void Function(Offset?)? onAnimeTap;
 
   const _GlassAppBar({
     required this.topPadding,
     required this.onSearchTap,
     required this.onSettingsTap,
-    this.onAnimeTap,
   });
 
   @override
@@ -398,49 +387,6 @@ class _GlassAppBar extends StatelessWidget {
               ),
             ),
             const SizedBox(width: 14),
-            // Anime shortcut chip within Media
-            Builder(
-              builder: (context) {
-                return GestureDetector(
-                  onTap: () {
-                    final box = context.findRenderObject() as RenderBox?;
-                    final offset = box != null
-                        ? box.localToGlobal(box.size.center(Offset.zero))
-                        : null;
-                    if (onAnimeTap != null) onAnimeTap!(offset);
-                  },
-                  child: Container(
-                    padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
-                    decoration: BoxDecoration(
-                      color: const Color(0xFF7C5CFF).withValues(alpha: 0.16),
-                      borderRadius: BorderRadius.circular(16),
-                      border: Border.all(
-                        color: const Color(0xFF7C5CFF).withValues(alpha: 0.35),
-                      ),
-                    ),
-                    child: const Row(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        Icon(
-                          Icons.animation_rounded,
-                          size: 15,
-                          color: Color(0xFF7C5CFF),
-                        ),
-                        SizedBox(width: 5),
-                        Text(
-                          'Anime',
-                          style: TextStyle(
-                            fontSize: 12,
-                            fontWeight: FontWeight.w700,
-                            color: Colors.white,
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                );
-              },
-            ),
             // Search Bar (Open and clickable on top)
             Expanded(
               child: Builder(

--- a/lib/pages/home/home_page.dart
+++ b/lib/pages/home/home_page.dart
@@ -15,13 +15,13 @@ import '../../services/glass_settings.dart';
 import '../../utils/route_transitions.dart';
 import '../../widgets/common/error_view.dart';
 import '../../widgets/movie/movie_slider_section.dart';
+import '../collection/collection_page.dart';
 import '../search/search_page.dart';
 import '../settings/settings_page.dart';
 import '../manga/manga_page.dart';
 import '../audiobooks/audiobooks_page.dart';
 import '../music/music_page.dart';
 import '../anime/anime_page.dart';
-import '../my_list/my_list_page.dart';
 
 import '../../widgets/common/liquid_dock.dart';
 import '../../services/app_updater_service.dart';
@@ -229,6 +229,15 @@ class _HomePageState extends State<HomePage> {
           topPadding: topPadding,
           onSearchTap: _navigateToSearch,
           onSettingsTap: _navigateToSettings,
+          onAnimeTap: (tapPosition) {
+            Navigator.push(
+              context,
+              LiquidRevealRoute(
+                page: const AnimePage(),
+                tapPosition: tapPosition,
+              ),
+            );
+          },
         ),
       ),
 
@@ -248,7 +257,11 @@ class _HomePageState extends State<HomePage> {
         child: Center(
           child: LiquidDock(
             items: [
-              DockItem(icon: Icons.home_rounded, label: 'Home', onTap: () {}),
+              DockItem(
+                icon: Icons.movie_filter_rounded,
+                label: 'Media',
+                onTap: () {},
+              ),
               DockItem(
                 icon: Icons.auto_stories_rounded,
                 label: 'Manga',
@@ -270,8 +283,7 @@ class _HomePageState extends State<HomePage> {
                     context,
                     LiquidRevealRoute(
                       page: const AudiobooksPage(),
-                      tapPosition:
-                          null, // Liquid reveal transition from center/dock
+                      tapPosition: null,
                     ),
                   );
                 },
@@ -290,60 +302,17 @@ class _HomePageState extends State<HomePage> {
                 },
               ),
               DockItem(
-                icon: Icons.animation_rounded,
-                label: 'Anime',
+                icon: Icons.video_library_rounded,
+                label: 'Collection',
                 onTap: () {
                   Navigator.push(
                     context,
                     LiquidRevealRoute(
-                      page: const AnimePage(),
+                      page: const CollectionPage(),
                       tapPosition: null,
                     ),
                   );
                 },
-              ),
-              DockItem(
-                icon: Icons.extension_rounded,
-                label: 'Addons',
-                onTap: () {},
-              ),
-              DockItem(
-                icon: Icons.download_rounded,
-                label: 'Downloads',
-                onTap: () {},
-              ),
-              DockItem(
-                icon: Icons.favorite_rounded,
-                label: 'My List',
-                onTap: () {
-                  Navigator.push(
-                    context,
-                    LiquidRevealRoute(
-                      page: const MyListPage(),
-                      tapPosition: null,
-                    ),
-                  );
-                },
-              ),
-              DockItem(
-                icon: Icons.bookmark_rounded,
-                label: 'Watchlist',
-                onTap: () {},
-              ),
-              DockItem(
-                icon: Icons.settings_rounded,
-                label: 'Settings',
-                onTap: () => _navigateToSettings(null),
-              ),
-              DockItem(
-                icon: Icons.person_rounded,
-                label: 'Profile',
-                onTap: () {},
-              ),
-              DockItem(
-                icon: Icons.search_rounded,
-                label: 'Search',
-                onTap: () => _navigateToSearch(null),
               ),
             ],
           ),
@@ -446,11 +415,13 @@ class _GlassAppBar extends StatelessWidget {
   final double topPadding;
   final void Function(Offset?) onSearchTap;
   final void Function(Offset?) onSettingsTap;
+  final void Function(Offset?)? onAnimeTap;
 
   const _GlassAppBar({
     required this.topPadding,
     required this.onSearchTap,
     required this.onSettingsTap,
+    this.onAnimeTap,
   });
 
   @override
@@ -491,6 +462,50 @@ class _GlassAppBar extends StatelessWidget {
                 letterSpacing: -0.5,
                 color: Colors.white,
               ),
+            ),
+            const SizedBox(width: 14),
+            // Anime shortcut chip within Media
+            Builder(
+              builder: (context) {
+                return GestureDetector(
+                  onTap: () {
+                    final box = context.findRenderObject() as RenderBox?;
+                    final offset = box != null
+                        ? box.localToGlobal(box.size.center(Offset.zero))
+                        : null;
+                    if (onAnimeTap != null) onAnimeTap!(offset);
+                  },
+                  child: Container(
+                    padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
+                    decoration: BoxDecoration(
+                      color: const Color(0xFF7C5CFF).withValues(alpha: 0.16),
+                      borderRadius: BorderRadius.circular(16),
+                      border: Border.all(
+                        color: const Color(0xFF7C5CFF).withValues(alpha: 0.35),
+                      ),
+                    ),
+                    child: const Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Icon(
+                          Icons.animation_rounded,
+                          size: 15,
+                          color: Color(0xFF7C5CFF),
+                        ),
+                        SizedBox(width: 5),
+                        Text(
+                          'Anime',
+                          style: TextStyle(
+                            fontSize: 12,
+                            fontWeight: FontWeight.w700,
+                            color: Colors.white,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                );
+              },
             ),
             const Spacer(),
             // Search

--- a/lib/pages/home/home_page.dart
+++ b/lib/pages/home/home_page.dart
@@ -13,6 +13,7 @@ import '../../services/addon/addon_manager.dart';
 import '../../services/metadata/metadata_service.dart';
 import '../../services/glass_settings.dart';
 import '../../utils/route_transitions.dart';
+import '../../widgets/common/app_dock.dart';
 import '../../widgets/common/error_view.dart';
 import '../../widgets/movie/movie_slider_section.dart';
 import '../collection/collection_page.dart';
@@ -250,74 +251,7 @@ class _HomePageState extends State<HomePage> {
         ),
 
       // ── Liquid Dock Navbar ──
-      Positioned(
-        bottom: 24,
-        left: 0,
-        right: 0,
-        child: Center(
-          child: LiquidDock(
-            items: [
-              DockItem(
-                icon: Icons.movie_filter_rounded,
-                label: 'Media',
-                onTap: () {},
-              ),
-              DockItem(
-                icon: Icons.auto_stories_rounded,
-                label: 'Manga',
-                onTap: () {
-                  Navigator.push(
-                    context,
-                    LiquidRevealRoute(
-                      page: const MangaPage(),
-                      tapPosition: null, // Reveals from center
-                    ),
-                  );
-                },
-              ),
-              DockItem(
-                icon: Icons.headphones_rounded,
-                label: 'Audiobooks',
-                onTap: () {
-                  Navigator.push(
-                    context,
-                    LiquidRevealRoute(
-                      page: const AudiobooksPage(),
-                      tapPosition: null,
-                    ),
-                  );
-                },
-              ),
-              DockItem(
-                icon: Icons.music_note_rounded,
-                label: 'Music',
-                onTap: () {
-                  Navigator.push(
-                    context,
-                    LiquidRevealRoute(
-                      page: const MusicPage(),
-                      tapPosition: null,
-                    ),
-                  );
-                },
-              ),
-              DockItem(
-                icon: Icons.video_library_rounded,
-                label: 'Collection',
-                onTap: () {
-                  Navigator.push(
-                    context,
-                    LiquidRevealRoute(
-                      page: const CollectionPage(),
-                      tapPosition: null,
-                    ),
-                  );
-                },
-              ),
-            ],
-          ),
-        ),
-      ),
+      const AppDock(currentHub: AppHub.media),
 
       // ── Intro Splash Screen ──
       Positioned.fill(child: _buildIntroOverlay(context)),

--- a/lib/pages/home/home_page.dart
+++ b/lib/pages/home/home_page.dart
@@ -441,34 +441,60 @@ class _GlassAppBar extends StatelessWidget {
                 );
               },
             ),
-            const Spacer(),
-            // Search
-            Builder(
-              builder: (context) {
-                return IconButton(
-                  icon: Icon(
-                    Icons.search_rounded,
-                    color: Colors.white.withValues(alpha: 0.65),
-                    size: 25,
-                  ),
-                  onPressed: () {
-                    final box = context.findRenderObject() as RenderBox?;
-                    final offset = box != null
-                        ? box.localToGlobal(box.size.center(Offset.zero))
-                        : null;
-                    onSearchTap(offset);
-                  },
-                );
-              },
+            // Search Bar (Open and clickable on top)
+            Expanded(
+              child: Builder(
+                builder: (context) {
+                  return GestureDetector(
+                    onTap: () {
+                      final box = context.findRenderObject() as RenderBox?;
+                      final offset = box != null
+                          ? box.localToGlobal(box.size.center(Offset.zero))
+                          : null;
+                      onSearchTap(offset);
+                    },
+                    child: Container(
+                      height: 38,
+                      padding: const EdgeInsets.symmetric(horizontal: 12),
+                      decoration: BoxDecoration(
+                        color: const Color(0xFF141824).withValues(alpha: 0.85),
+                        borderRadius: BorderRadius.circular(12),
+                        border: Border.all(
+                          color: Colors.white.withValues(alpha: 0.08),
+                        ),
+                      ),
+                      child: Row(
+                        children: [
+                          Icon(
+                            Icons.search_rounded,
+                            size: 18,
+                            color: Colors.white.withValues(alpha: 0.5),
+                          ),
+                          const SizedBox(width: 8),
+                          Text(
+                            'Search movies, series, anime...',
+                            style: TextStyle(
+                              color: Colors.white.withValues(alpha: 0.4),
+                              fontSize: 13,
+                              fontWeight: FontWeight.w500,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  );
+                },
+              ),
             ),
-            // Settings
+            const SizedBox(width: 10),
+            // Settings Icon
             Builder(
               builder: (context) {
                 return IconButton(
                   icon: Icon(
                     Icons.settings_rounded,
                     color: Colors.white.withValues(alpha: 0.65),
-                    size: 24,
+                    size: 22,
                   ),
                   onPressed: () {
                     final box = context.findRenderObject() as RenderBox?;

--- a/lib/pages/home/home_page.dart
+++ b/lib/pages/home/home_page.dart
@@ -229,7 +229,6 @@ class _HomePageState extends State<HomePage> {
         child: _GlassAppBar(
           topPadding: topPadding,
           onSearchTap: _navigateToSearch,
-          onSettingsTap: _navigateToSettings,
         ),
       ),
 
@@ -339,12 +338,10 @@ class _HomePageState extends State<HomePage> {
 class _GlassAppBar extends StatelessWidget {
   final double topPadding;
   final void Function(Offset?) onSearchTap;
-  final void Function(Offset?) onSettingsTap;
 
   const _GlassAppBar({
     required this.topPadding,
     required this.onSearchTap,
-    required this.onSettingsTap,
   });
 
   @override
@@ -355,7 +352,7 @@ class _GlassAppBar extends StatelessWidget {
           top: topPadding + 10,
           bottom: 14,
           left: 20,
-          right: 8,
+          right: 20,
         ),
         decoration: BoxDecoration(
           gradient: LinearGradient(
@@ -386,8 +383,8 @@ class _GlassAppBar extends StatelessWidget {
                 color: Colors.white,
               ),
             ),
-            const SizedBox(width: 14),
-            // Search Bar (Open and clickable on top)
+            const SizedBox(width: 18),
+            // Search Bar (Open and clickable on top, filling available space)
             Expanded(
               child: Builder(
                 builder: (context) {
@@ -400,28 +397,28 @@ class _GlassAppBar extends StatelessWidget {
                       onSearchTap(offset);
                     },
                     child: Container(
-                      height: 38,
-                      padding: const EdgeInsets.symmetric(horizontal: 12),
+                      height: 40,
+                      padding: const EdgeInsets.symmetric(horizontal: 14),
                       decoration: BoxDecoration(
                         color: const Color(0xFF141824).withValues(alpha: 0.85),
                         borderRadius: BorderRadius.circular(12),
                         border: Border.all(
-                          color: Colors.white.withValues(alpha: 0.08),
+                          color: Colors.white.withValues(alpha: 0.10),
                         ),
                       ),
                       child: Row(
                         children: [
                           Icon(
                             Icons.search_rounded,
-                            size: 18,
-                            color: Colors.white.withValues(alpha: 0.5),
+                            size: 19,
+                            color: Colors.white.withValues(alpha: 0.55),
                           ),
-                          const SizedBox(width: 8),
+                          const SizedBox(width: 10),
                           Text(
                             'Search movies, series, anime...',
                             style: TextStyle(
-                              color: Colors.white.withValues(alpha: 0.4),
-                              fontSize: 13,
+                              color: Colors.white.withValues(alpha: 0.45),
+                              fontSize: 13.5,
                               fontWeight: FontWeight.w500,
                             ),
                           ),
@@ -431,26 +428,6 @@ class _GlassAppBar extends StatelessWidget {
                   );
                 },
               ),
-            ),
-            const SizedBox(width: 10),
-            // Settings Icon
-            Builder(
-              builder: (context) {
-                return IconButton(
-                  icon: Icon(
-                    Icons.settings_rounded,
-                    color: Colors.white.withValues(alpha: 0.65),
-                    size: 22,
-                  ),
-                  onPressed: () {
-                    final box = context.findRenderObject() as RenderBox?;
-                    final offset = box != null
-                        ? box.localToGlobal(box.size.center(Offset.zero))
-                        : null;
-                    onSettingsTap(offset);
-                  },
-                );
-              },
             ),
           ],
         ),

--- a/lib/pages/manga/manga_page.dart
+++ b/lib/pages/manga/manga_page.dart
@@ -5,6 +5,7 @@ import 'package:liquid_glass_easy/liquid_glass_easy.dart';
 import '../../models/manga/manga.dart';
 import '../../models/manga/manga_chapter.dart';
 import '../../services/manga/manga_service.dart';
+import '../../widgets/common/app_dock.dart';
 import '../../widgets/common/custom_scroll_track.dart';
 import '../../widgets/manga/manga_card.dart';
 import 'manga_reader_page.dart';
@@ -194,6 +195,9 @@ class _MangaPageState extends State<MangaPage> {
                 bottom: 40,
                 child: CustomScrollTrack(controller: _scrollController),
               ),
+
+            // Bottom Navigation Dock
+            const AppDock(currentHub: AppHub.manga),
           ],
         ),
       ),

--- a/lib/pages/music/music_page.dart
+++ b/lib/pages/music/music_page.dart
@@ -11,6 +11,7 @@ import '../../models/music/music_track.dart';
 import '../../services/music/music_service.dart';
 import '../../services/music/music_player_controller.dart';
 import '../../services/music/music_library_service.dart';
+import '../../widgets/common/app_dock.dart';
 import '../../widgets/common/performance_liquid_lens.dart';
 import '../../widgets/common/slider_arrow.dart';
 import '../settings/settings_page.dart';
@@ -890,6 +891,9 @@ class _MusicPageState extends State<MusicPage> {
                   ),
                 ),
               ),
+
+            // Persistent Hub Navigation Dock
+            const AppDock(currentHub: AppHub.music),
           ],
         ),
       ),

--- a/lib/pages/player/player_screen.dart
+++ b/lib/pages/player/player_screen.dart
@@ -14,6 +14,7 @@ import '../../models/playback/playback_history_item.dart';
 import '../../models/stream/stream_model.dart';
 import '../../services/playback/playback_history_service.dart';
 import '../../services/stream/torrent_stream_service.dart';
+import '../../services/trakt/trakt_sync_service.dart';
 import '../../services/glass_settings.dart';
 import '../../widgets/common/performance_liquid_lens.dart';
 import 'package:fvp/fvp.dart';
@@ -210,6 +211,21 @@ class _PlayerScreenState extends State<PlayerScreen>
           lastWatched: DateTime.now(),
         );
         PlaybackHistoryService.saveProgress(historyItem);
+
+        // Scrobble progress to Trakt every 15s or when complete
+        if (pos.inSeconds % 15 == 0 || historyItem.isCompleted) {
+          final progressPercent = (pos.inMilliseconds / dur.inMilliseconds) * 100.0;
+          TraktSyncService.scrobblePlayback(
+            action: historyItem.isCompleted ? 'stop' : 'start',
+            progressPercent: progressPercent,
+            title: widget.detail!.name,
+            imdbId: widget.detail!.id.startsWith('tt') ? widget.detail!.id : null,
+            tmdbId: widget.detail!.tmdbId != null ? int.tryParse(widget.detail!.tmdbId!) : null,
+            season: widget.episode?.season,
+            episode: widget.episode?.episode,
+            type: widget.detail!.type,
+          );
+        }
       }
     }
   }

--- a/lib/pages/player/player_screen.dart
+++ b/lib/pages/player/player_screen.dart
@@ -10,7 +10,9 @@ import 'package:playtorrio/models/subtitle/subtitle_model.dart';
 import 'package:playtorrio/services/subtitles/subtitle_service.dart';
 import 'package:liquid_glass_easy/liquid_glass_easy.dart';
 
+import '../../models/playback/playback_history_item.dart';
 import '../../models/stream/stream_model.dart';
+import '../../services/playback/playback_history_service.dart';
 import '../../services/stream/torrent_stream_service.dart';
 import '../../services/glass_settings.dart';
 import '../../widgets/common/performance_liquid_lens.dart';
@@ -133,7 +135,14 @@ class _PlayerScreenState extends State<PlayerScreen>
         cleanUri,
         httpHeaders: playerHeaders,
       );
-      await _controller!.initialize();
+      await _controller!.initialize().timeout(
+        const Duration(seconds: 15),
+        onTimeout: () {
+          throw TimeoutException(
+            'Stream connection timed out after 15 seconds. The host server may be slow or offline.',
+          );
+        },
+      );
 
       print(
         '[PlayerScreen SUCCESS] Video controller initialized successfully for $streamUrl',
@@ -144,6 +153,17 @@ class _PlayerScreenState extends State<PlayerScreen>
         _isLoading = false;
       });
 
+      // Resume from history if previously watched
+      if (widget.detail != null) {
+        final historyItem = PlaybackHistoryService.getProgress(
+          widget.episode?.id ?? widget.detail!.id,
+        );
+        if (historyItem != null && historyItem.position.inSeconds > 10) {
+          _controller!.seekTo(historyItem.position);
+        }
+      }
+
+      _controller!.addListener(_onPlaybackUpdate);
       _controller!.play();
       _startHideControlsTimer();
     } catch (e, stackTrace) {
@@ -165,6 +185,32 @@ class _PlayerScreenState extends State<PlayerScreen>
       setState(() {
         _statusMessage = displayMessage;
       });
+    }
+  }
+
+  void _onPlaybackUpdate() {
+    if (_controller == null || !_controller!.value.isInitialized) return;
+
+    if (widget.detail != null) {
+      final pos = _controller!.value.position;
+      final dur = _controller!.value.duration;
+      if (dur.inSeconds > 0 && pos.inSeconds % 5 == 0) {
+        final itemId = widget.episode?.id ?? widget.detail!.id;
+        final historyItem = PlaybackHistoryItem(
+          id: itemId,
+          title: widget.detail!.name,
+          poster: widget.detail!.poster,
+          backdrop: widget.backdropUrl,
+          type: widget.detail!.type,
+          episodeTitle: widget.episode?.title,
+          seasonNumber: widget.episode?.season,
+          episodeNumber: widget.episode?.episode,
+          position: pos,
+          duration: dur,
+          lastWatched: DateTime.now(),
+        );
+        PlaybackHistoryService.saveProgress(historyItem);
+      }
     }
   }
 
@@ -641,13 +687,16 @@ class _PlayerScreenState extends State<PlayerScreen>
   @override
   void dispose() {
     _hideTimer?.cancel();
+    if (_controller != null) {
+      _controller!.removeListener(_onPlaybackUpdate);
+      _controller!.dispose();
+    }
     SystemChrome.setPreferredOrientations([
       DeviceOrientation.portraitUp,
       DeviceOrientation.portraitDown,
       DeviceOrientation.landscapeLeft,
       DeviceOrientation.landscapeRight,
     ]);
-    _controller?.dispose();
     _logoAnimController.dispose();
     TorrentStreamService().cleanup();
     super.dispose();

--- a/lib/pages/settings/settings_page.dart
+++ b/lib/pages/settings/settings_page.dart
@@ -2,7 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 
 import '../../models/addon/addon.dart';
+import '../../models/debrid/debrid_account.dart';
 import '../../services/addon/addon_manager.dart';
+import '../../services/debrid/debrid_service.dart';
 import '../../services/glass_settings.dart';
 import '../../services/app_updater_service.dart';
 import '../../services/trakt/trakt_auth_service.dart';
@@ -253,6 +255,10 @@ class _SettingsPageState extends State<SettingsPage> {
           _buildTraktSection(),
           const SizedBox(height: 28),
 
+          // ── Debrid Providers section ──
+          _buildDebridSection(),
+          const SizedBox(height: 28),
+
           // ── Section title ──
           Row(
             children: [
@@ -440,6 +446,230 @@ class _SettingsPageState extends State<SettingsPage> {
         );
       },
     );
+  }
+
+  // ── Debrid section ─────────────────────────────────────────────────────
+
+  Widget _buildDebridSection() {
+    final debrid = DebridService.instance;
+
+    return ValueListenableBuilder<List<DebridAccount>>(
+      valueListenable: debrid.accounts,
+      builder: (context, accounts, _) {
+        final rdAccount = debrid.getAccount(DebridProvider.realDebrid);
+        final torboxAccount = debrid.getAccount(DebridProvider.torbox);
+
+        return Container(
+          padding: const EdgeInsets.all(16),
+          decoration: BoxDecoration(
+            color: const Color(0xFF12151E),
+            borderRadius: BorderRadius.circular(16),
+            border: Border.all(color: Colors.white.withOpacity(0.08)),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Container(
+                    width: 42,
+                    height: 42,
+                    decoration: BoxDecoration(
+                      color: const Color(0xFF00D294).withOpacity(0.14),
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                    child: const Icon(
+                      Icons.cloud_download_rounded,
+                      color: Color(0xFF00D294),
+                    ),
+                  ),
+                  const SizedBox(width: 14),
+                  const Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          'Debrid Services',
+                          style: TextStyle(
+                            fontSize: 16,
+                            fontWeight: FontWeight.w800,
+                          ),
+                        ),
+                        SizedBox(height: 4),
+                        Text(
+                          'High-speed cached torrent streaming (Real-Debrid & Torbox)',
+                          style: TextStyle(
+                            color: Colors.white54,
+                            fontSize: 12.5,
+                            height: 1.35,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 16),
+              _buildDebridTile(
+                providerName: 'Real-Debrid',
+                account: rdAccount,
+                onConnect: () => _showDebridTokenDialog(DebridProvider.realDebrid),
+                onDisconnect: () => debrid.removeAccount(DebridProvider.realDebrid),
+              ),
+              const SizedBox(height: 10),
+              _buildDebridTile(
+                providerName: 'Torbox',
+                account: torboxAccount,
+                onConnect: () => _showDebridTokenDialog(DebridProvider.torbox),
+                onDisconnect: () => debrid.removeAccount(DebridProvider.torbox),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildDebridTile({
+    required String providerName,
+    required DebridAccount? account,
+    required VoidCallback onConnect,
+    required VoidCallback onDisconnect,
+  }) {
+    final isConnected = account != null;
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+      decoration: BoxDecoration(
+        color: const Color(0xFF191D28),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(
+          color: isConnected
+              ? const Color(0xFF00D294).withOpacity(0.3)
+              : Colors.white.withOpacity(0.06),
+        ),
+      ),
+      child: Row(
+        children: [
+          Icon(
+            isConnected ? Icons.check_circle_rounded : Icons.radio_button_unchecked_rounded,
+            size: 18,
+            color: isConnected ? const Color(0xFF00D294) : Colors.white38,
+          ),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  providerName,
+                  style: const TextStyle(
+                    fontWeight: FontWeight.w700,
+                    fontSize: 14,
+                    color: Colors.white,
+                  ),
+                ),
+                if (isConnected) ...[
+                  const SizedBox(height: 2),
+                  Text(
+                    account.username != null ? 'Connected as ${account.username}' : 'Active API Token',
+                    style: const TextStyle(fontSize: 11.5, color: Colors.white54),
+                  ),
+                ],
+              ],
+            ),
+          ),
+          TextButton(
+            onPressed: isConnected ? onDisconnect : onConnect,
+            style: TextButton.styleFrom(
+              foregroundColor: isConnected ? Colors.redAccent : const Color(0xFF00D294),
+              textStyle: const TextStyle(fontWeight: FontWeight.w700, fontSize: 12.5),
+            ),
+            child: Text(isConnected ? 'Disconnect' : 'Connect'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _showDebridTokenDialog(DebridProvider provider) async {
+    final controller = TextEditingController();
+    final debrid = DebridService.instance;
+
+    final token = await showDialog<String>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        backgroundColor: const Color(0xFF151822),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+        title: Text(
+          'Connect ${provider.displayName}',
+          style: const TextStyle(fontWeight: FontWeight.w800, color: Colors.white),
+        ),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Paste your ${provider.displayName} API token/key to enable instant cloud stream resolving.',
+              style: TextStyle(color: Colors.white.withOpacity(0.7), fontSize: 13),
+            ),
+            const SizedBox(height: 14),
+            TextField(
+              controller: controller,
+              autofocus: true,
+              style: const TextStyle(color: Colors.white, fontSize: 14),
+              decoration: InputDecoration(
+                hintText: 'API Key / Token',
+                hintStyle: TextStyle(color: Colors.white.withOpacity(0.3)),
+                filled: true,
+                fillColor: const Color(0xFF0D1017),
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(10),
+                  borderSide: BorderSide.none,
+                ),
+              ),
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx),
+            child: Text('Cancel', style: TextStyle(color: Colors.white.withOpacity(0.6))),
+          ),
+          ElevatedButton(
+            onPressed: () => Navigator.pop(ctx, controller.text.trim()),
+            style: ElevatedButton.styleFrom(
+              backgroundColor: const Color(0xFF00D294),
+              shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
+            ),
+            child: const Text('Save & Verify', style: TextStyle(color: Colors.black, fontWeight: FontWeight.bold)),
+          ),
+        ],
+      ),
+    );
+
+    if (token != null && token.isNotEmpty) {
+      bool success = false;
+      if (provider == DebridProvider.realDebrid) {
+        success = await debrid.authenticateRealDebrid(token);
+      } else if (provider == DebridProvider.torbox) {
+        success = await debrid.authenticateTorbox(token);
+      }
+
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              success
+                  ? '${provider.displayName} connected successfully!'
+                  : 'Failed to verify token for ${provider.displayName}.',
+            ),
+            backgroundColor: success ? const Color(0xFF1E8E3E) : Colors.redAccent,
+            behavior: SnackBarBehavior.floating,
+          ),
+        );
+      }
+    }
   }
 
   // ── Add addon flow ──────────────────────────────────────────────────────

--- a/lib/services/debrid/debrid_service.dart
+++ b/lib/services/debrid/debrid_service.dart
@@ -1,0 +1,129 @@
+import 'dart:convert';
+import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
+import 'package:shared_preferences/shared_preferences.dart';
+import '../../models/debrid/debrid_account.dart';
+
+class DebridService {
+  DebridService._();
+  static final DebridService instance = DebridService._();
+
+  static const _storageKey = 'debrid_accounts_v1';
+  final ValueNotifier<List<DebridAccount>> accounts = ValueNotifier<List<DebridAccount>>([]);
+  final ValueNotifier<bool> isLoading = ValueNotifier<bool>(false);
+
+  Future<void> initialize() async {
+    final prefs = await SharedPreferences.getInstance();
+    final stored = prefs.getString(_storageKey);
+    if (stored != null) {
+      try {
+        final list = (jsonDecode(stored) as List)
+            .map((e) => DebridAccount.fromJson(e as Map<String, dynamic>))
+            .toList();
+        accounts.value = list;
+      } catch (_) {
+        accounts.value = [];
+      }
+    }
+  }
+
+  Future<void> _persist() async {
+    final prefs = await SharedPreferences.getInstance();
+    final data = jsonEncode(accounts.value.map((e) => e.toJson()).toList());
+    await prefs.setString(_storageKey, data);
+  }
+
+  bool isConfigured(DebridProvider provider) {
+    return accounts.value.any((a) => a.provider == provider && a.apiKey.isNotEmpty);
+  }
+
+  DebridAccount? getAccount(DebridProvider provider) {
+    try {
+      return accounts.value.firstWhere((a) => a.provider == provider);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  Future<bool> authenticateRealDebrid(String apiToken) async {
+    isLoading.value = true;
+    try {
+      final response = await http.get(
+        Uri.parse('https://api.real-debrid.com/rest/1.0/user'),
+        headers: {'Authorization': 'Bearer $apiToken'},
+      );
+
+      if (response.statusCode == 200) {
+        final data = jsonDecode(response.body) as Map<String, dynamic>;
+        final username = data['username']?.toString();
+        final email = data['email']?.toString();
+        final expiration = data['expiration'] != null
+            ? DateTime.tryParse(data['expiration'].toString())
+            : null;
+        final type = data['type']?.toString();
+        final isPremium = type == 'premium';
+
+        final account = DebridAccount(
+          provider: DebridProvider.realDebrid,
+          apiKey: apiToken,
+          username: username,
+          email: email,
+          expirationDate: expiration,
+          isPremium: isPremium,
+        );
+
+        final updated = accounts.value.where((a) => a.provider != DebridProvider.realDebrid).toList();
+        updated.add(account);
+        accounts.value = updated;
+        await _persist();
+        isLoading.value = false;
+        return true;
+      }
+    } catch (e) {
+      debugPrint('Real-Debrid auth error: $e');
+    }
+    isLoading.value = false;
+    return false;
+  }
+
+  Future<bool> authenticateTorbox(String apiToken) async {
+    isLoading.value = true;
+    try {
+      final response = await http.get(
+        Uri.parse('https://api.torbox.app/v1/api/user/me'),
+        headers: {'Authorization': 'Bearer $apiToken'},
+      );
+
+      if (response.statusCode == 200) {
+        final json = jsonDecode(response.body) as Map<String, dynamic>;
+        final data = json['data'] as Map<String, dynamic>?;
+        final email = data?['email']?.toString();
+        final plan = data?['plan'] as int? ?? 0;
+
+        final account = DebridAccount(
+          provider: DebridProvider.torbox,
+          apiKey: apiToken,
+          username: email?.split('@').first,
+          email: email,
+          isPremium: plan > 0,
+        );
+
+        final updated = accounts.value.where((a) => a.provider != DebridProvider.torbox).toList();
+        updated.add(account);
+        accounts.value = updated;
+        await _persist();
+        isLoading.value = false;
+        return true;
+      }
+    } catch (e) {
+      debugPrint('Torbox auth error: $e');
+    }
+    isLoading.value = false;
+    return false;
+  }
+
+  Future<void> removeAccount(DebridProvider provider) async {
+    accounts.value = accounts.value.where((a) => a.provider != provider).toList();
+    await _persist();
+  }
+}

--- a/lib/services/download/download_service.dart
+++ b/lib/services/download/download_service.dart
@@ -1,0 +1,79 @@
+import 'dart:convert';
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import '../../models/download/download_item.dart';
+
+abstract final class DownloadService {
+  static const _storageKey = 'downloads_v1';
+  static final ValueNotifier<List<DownloadItem>> downloads = ValueNotifier<List<DownloadItem>>([]);
+
+  static Future<void> initialize() async {
+    final prefs = await SharedPreferences.getInstance();
+    final stored = prefs.getString(_storageKey);
+    if (stored != null) {
+      try {
+        final list = (jsonDecode(stored) as List)
+            .map((e) => DownloadItem.fromJson(e as Map<String, dynamic>))
+            .toList();
+        downloads.value = list;
+      } catch (_) {
+        downloads.value = [];
+      }
+    }
+  }
+
+  static Future<void> _persist() async {
+    final prefs = await SharedPreferences.getInstance();
+    final data = jsonEncode(downloads.value.map((e) => e.toJson()).toList());
+    await prefs.setString(_storageKey, data);
+  }
+
+  static void addDownload(DownloadItem item) {
+    if (downloads.value.any((d) => d.id == item.id)) return;
+    downloads.value = [item, ...downloads.value];
+    _persist();
+  }
+
+  static void updateProgress(String id, double progress, int receivedBytes, int totalBytes, DownloadStatus status) {
+    final index = downloads.value.indexWhere((d) => d.id == id);
+    if (index != -1) {
+      final updated = downloads.value[index].copyWith(
+        progress: progress,
+        receivedBytes: receivedBytes,
+        totalBytes: totalBytes,
+        status: status,
+      );
+      final list = List<DownloadItem>.from(downloads.value);
+      list[index] = updated;
+      downloads.value = list;
+      _persist();
+    }
+  }
+
+  static void removeDownload(String id) {
+    downloads.value = downloads.value.where((d) => d.id != id).toList();
+    _persist();
+  }
+
+  static void pauseDownload(String id) {
+    final index = downloads.value.indexWhere((d) => d.id == id);
+    if (index != -1) {
+      final updated = downloads.value[index].copyWith(status: DownloadStatus.paused);
+      final list = List<DownloadItem>.from(downloads.value);
+      list[index] = updated;
+      downloads.value = list;
+      _persist();
+    }
+  }
+
+  static void resumeDownload(String id) {
+    final index = downloads.value.indexWhere((d) => d.id == id);
+    if (index != -1) {
+      final updated = downloads.value[index].copyWith(status: DownloadStatus.downloading);
+      final list = List<DownloadItem>.from(downloads.value);
+      list[index] = updated;
+      downloads.value = list;
+      _persist();
+    }
+  }
+}

--- a/lib/services/playback/playback_history_service.dart
+++ b/lib/services/playback/playback_history_service.dart
@@ -1,0 +1,56 @@
+import 'dart:convert';
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import '../../models/playback/playback_history_item.dart';
+
+abstract final class PlaybackHistoryService {
+  static const _storageKey = 'playback_history_v1';
+  static const int maxItems = 100;
+
+  static final ValueNotifier<List<PlaybackHistoryItem>> history =
+      ValueNotifier<List<PlaybackHistoryItem>>([]);
+
+  static Future<void> initialize() async {
+    final prefs = await SharedPreferences.getInstance();
+    final stored = prefs.getString(_storageKey);
+    if (stored != null) {
+      try {
+        final list = (jsonDecode(stored) as List)
+            .map((e) => PlaybackHistoryItem.fromJson(e as Map<String, dynamic>))
+            .toList();
+        history.value = list;
+      } catch (_) {
+        history.value = [];
+      }
+    }
+  }
+
+  static Future<void> _persist() async {
+    final prefs = await SharedPreferences.getInstance();
+    final data = jsonEncode(history.value.map((e) => e.toJson()).toList());
+    await prefs.setString(_storageKey, data);
+  }
+
+  static PlaybackHistoryItem? getProgress(String id) {
+    try {
+      return history.value.firstWhere((h) => h.id == id);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  static void saveProgress(PlaybackHistoryItem item) {
+    final filtered = history.value.where((h) => h.id != item.id).toList();
+    final updated = [item, ...filtered];
+    if (updated.length > maxItems) {
+      updated.removeRange(maxItems, updated.length);
+    }
+    history.value = updated;
+    _persist();
+  }
+
+  static void removeProgress(String id) {
+    history.value = history.value.where((h) => h.id != id).toList();
+    _persist();
+  }
+}

--- a/lib/services/trakt/trakt_api_service.dart
+++ b/lib/services/trakt/trakt_api_service.dart
@@ -84,4 +84,33 @@ class TraktApiService {
     }
     return null;
   }
+
+  /// Scrobble watching/progress/pause/stop to Trakt.
+  /// [action]: 'start', 'pause', 'stop'
+  /// [progress]: 0.0 to 100.0 percent
+  static Future<bool> scrobble({
+    required String action,
+    required double progress,
+    Map<String, dynamic>? movie,
+    Map<String, dynamic>? show,
+    Map<String, dynamic>? episode,
+  }) async {
+    final headers = await _headers();
+    final uri = Uri.parse('$_baseUrl/scrobble/$action');
+    final payload = <String, dynamic>{
+      'progress': progress.clamp(0.0, 100.0),
+      if (movie != null) 'movie': movie,
+      if (show != null) 'show': show,
+      if (episode != null) 'episode': episode,
+    };
+
+    try {
+      final response = await http
+          .post(uri, headers: headers, body: jsonEncode(payload))
+          .timeout(const Duration(seconds: 8));
+      return response.statusCode == 201;
+    } catch (_) {
+      return false;
+    }
+  }
 }

--- a/lib/services/trakt/trakt_sync_service.dart
+++ b/lib/services/trakt/trakt_sync_service.dart
@@ -150,4 +150,51 @@ class TraktSyncService {
     MyListService.remove(item);
     return true;
   }
+
+  /// Automatically scrobbles playback progress to Trakt
+  static Future<void> scrobblePlayback({
+    required String action,
+    required double progressPercent,
+    required String title,
+    String? imdbId,
+    int? tmdbId,
+    int? season,
+    int? episode,
+    String type = 'movie',
+  }) async {
+    final auth = TraktAuthService();
+    if (!auth.isLoggedIn.value) return;
+
+    final ids = <String, dynamic>{
+      if (imdbId != null && imdbId.isNotEmpty) 'imdb': imdbId,
+      if (tmdbId != null) 'tmdb': tmdbId,
+    };
+
+    if (type == 'series' || type == 'anime') {
+      final showMap = <String, dynamic>{
+        'title': title,
+        if (ids.isNotEmpty) 'ids': ids,
+      };
+      final episodeMap = <String, dynamic>{
+        if (season != null) 'season': season,
+        if (episode != null) 'number': episode,
+      };
+      await TraktApiService.scrobble(
+        action: action,
+        progress: progressPercent,
+        show: showMap,
+        episode: episodeMap,
+      );
+    } else {
+      final movieMap = <String, dynamic>{
+        'title': title,
+        if (ids.isNotEmpty) 'ids': ids,
+      };
+      await TraktApiService.scrobble(
+        action: action,
+        progress: progressPercent,
+        movie: movieMap,
+      );
+    }
+  }
 }

--- a/lib/widgets/common/app_dock.dart
+++ b/lib/widgets/common/app_dock.dart
@@ -5,6 +5,7 @@ import '../../pages/collection/collection_page.dart';
 import '../../pages/home/home_page.dart';
 import '../../pages/manga/manga_page.dart';
 import '../../pages/music/music_page.dart';
+import '../../pages/settings/settings_page.dart';
 import '../../utils/route_transitions.dart';
 import 'liquid_dock.dart';
 
@@ -14,6 +15,7 @@ enum AppHub {
   audiobooks,
   music,
   collection,
+  settings,
 }
 
 class AppDock extends StatelessWidget {
@@ -26,6 +28,17 @@ class AppDock extends StatelessWidget {
 
   void _navigateTo(BuildContext context, AppHub targetHub) {
     if (targetHub == currentHub) return;
+
+    if (targetHub == AppHub.settings) {
+      Navigator.push(
+        context,
+        LiquidRevealRoute(
+          page: const SettingsPage(),
+          tapPosition: null,
+        ),
+      );
+      return;
+    }
 
     Widget page;
     switch (targetHub) {
@@ -43,6 +56,9 @@ class AppDock extends StatelessWidget {
         break;
       case AppHub.collection:
         page = const CollectionPage();
+        break;
+      case AppHub.settings:
+        page = const SettingsPage();
         break;
     }
 
@@ -88,6 +104,11 @@ class AppDock extends StatelessWidget {
               icon: Icons.video_library_rounded,
               label: 'Collection',
               onTap: () => _navigateTo(context, AppHub.collection),
+            ),
+            DockItem(
+              icon: Icons.settings_rounded,
+              label: 'Settings',
+              onTap: () => _navigateTo(context, AppHub.settings),
             ),
           ],
         ),

--- a/lib/widgets/common/app_dock.dart
+++ b/lib/widgets/common/app_dock.dart
@@ -66,12 +66,17 @@ class AppDock extends StatelessWidget {
         break;
     }
 
-    Navigator.pushReplacement(
+    // Use pushAndRemoveUntil keeping the first route (app root) so the
+    // system/back/pop behavior correctly returns to the Home root instead
+    // of leaving an empty stack (which caused the black screen). Settings
+    // still use a normal push so they behave like a modal overlay.
+    Navigator.pushAndRemoveUntil(
       context,
       LiquidRevealRoute(
         page: page,
         tapPosition: null,
       ),
+      (route) => route.isFirst,
     );
   }
 

--- a/lib/widgets/common/app_dock.dart
+++ b/lib/widgets/common/app_dock.dart
@@ -11,6 +11,7 @@ import 'liquid_dock.dart';
 
 enum AppHub {
   media,
+  anime,
   manga,
   audiobooks,
   music,
@@ -44,6 +45,9 @@ class AppDock extends StatelessWidget {
     switch (targetHub) {
       case AppHub.media:
         page = const HomePage();
+        break;
+      case AppHub.anime:
+        page = const AnimePage();
         break;
       case AppHub.manga:
         page = const MangaPage();
@@ -82,8 +86,13 @@ class AppDock extends StatelessWidget {
           items: [
             DockItem(
               icon: Icons.movie_filter_rounded,
-              label: 'Media',
+              label: 'Movies & Series',
               onTap: () => _navigateTo(context, AppHub.media),
+            ),
+            DockItem(
+              icon: Icons.animation_rounded,
+              label: 'Anime',
+              onTap: () => _navigateTo(context, AppHub.anime),
             ),
             DockItem(
               icon: Icons.auto_stories_rounded,

--- a/lib/widgets/common/app_dock.dart
+++ b/lib/widgets/common/app_dock.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/material.dart';
+import '../../pages/anime/anime_page.dart';
+import '../../pages/audiobooks/audiobooks_page.dart';
+import '../../pages/collection/collection_page.dart';
+import '../../pages/home/home_page.dart';
+import '../../pages/manga/manga_page.dart';
+import '../../pages/music/music_page.dart';
 import '../../utils/route_transitions.dart';
-import '../anime/anime_page.dart';
-import '../audiobooks/audiobooks_page.dart';
-import '../collection/collection_page.dart';
-import '../home/home_page.dart';
-import '../manga/manga_page.dart';
-import '../music/music_page.dart';
 import 'liquid_dock.dart';
 
 enum AppHub {

--- a/lib/widgets/common/app_dock.dart
+++ b/lib/widgets/common/app_dock.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/material.dart';
+import '../../utils/route_transitions.dart';
+import '../anime/anime_page.dart';
+import '../audiobooks/audiobooks_page.dart';
+import '../collection/collection_page.dart';
+import '../home/home_page.dart';
+import '../manga/manga_page.dart';
+import '../music/music_page.dart';
+import 'liquid_dock.dart';
+
+enum AppHub {
+  media,
+  manga,
+  audiobooks,
+  music,
+  collection,
+}
+
+class AppDock extends StatelessWidget {
+  final AppHub currentHub;
+
+  const AppDock({
+    super.key,
+    required this.currentHub,
+  });
+
+  void _navigateTo(BuildContext context, AppHub targetHub) {
+    if (targetHub == currentHub) return;
+
+    Widget page;
+    switch (targetHub) {
+      case AppHub.media:
+        page = const HomePage();
+        break;
+      case AppHub.manga:
+        page = const MangaPage();
+        break;
+      case AppHub.audiobooks:
+        page = const AudiobooksPage();
+        break;
+      case AppHub.music:
+        page = const MusicPage();
+        break;
+      case AppHub.collection:
+        page = const CollectionPage();
+        break;
+    }
+
+    Navigator.pushReplacement(
+      context,
+      LiquidRevealRoute(
+        page: page,
+        tapPosition: null,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Positioned(
+      bottom: 24,
+      left: 0,
+      right: 0,
+      child: Center(
+        child: LiquidDock(
+          items: [
+            DockItem(
+              icon: Icons.movie_filter_rounded,
+              label: 'Media',
+              onTap: () => _navigateTo(context, AppHub.media),
+            ),
+            DockItem(
+              icon: Icons.auto_stories_rounded,
+              label: 'Manga',
+              onTap: () => _navigateTo(context, AppHub.manga),
+            ),
+            DockItem(
+              icon: Icons.headphones_rounded,
+              label: 'Audiobooks',
+              onTap: () => _navigateTo(context, AppHub.audiobooks),
+            ),
+            DockItem(
+              icon: Icons.music_note_rounded,
+              label: 'Music',
+              onTap: () => _navigateTo(context, AppHub.music),
+            ),
+            DockItem(
+              icon: Icons.video_library_rounded,
+              label: 'Collection',
+              onTap: () => _navigateTo(context, AppHub.collection),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/test/models/cast_member_test.dart
+++ b/test/models/cast_member_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:playtorrio/models/movie/cast_member.dart';
+
+void main() {
+  group('CastMember & CrewMember', () {
+    test('CastMember parses from string', () {
+      final cast = CastMember.fromJson('Leonardo DiCaprio');
+      expect(cast.name, 'Leonardo DiCaprio');
+      expect(cast.character, isNull);
+    });
+
+    test('CastMember parses from JSON map with profile image', () {
+      final cast = CastMember.fromJson({
+        'name': 'Cillian Murphy',
+        'character': 'J. Robert Oppenheimer',
+        'profile_path': '/3DOT88s9mFfK64nN1x.jpg',
+      });
+      expect(cast.name, 'Cillian Murphy');
+      expect(cast.character, 'J. Robert Oppenheimer');
+      expect(cast.profileUrl, 'https://image.tmdb.org/t/p/w276_and_h350_face/3DOT88s9mFfK64nN1x.jpg');
+    });
+
+    test('CrewMember parses director from map', () {
+      final crew = CrewMember.fromJson({
+        'name': 'Christopher Nolan',
+        'job': 'Director',
+        'profile_path': '/x8B4P0zH4n8k.jpg',
+      });
+      expect(crew.name, 'Christopher Nolan');
+      expect(crew.job, 'Director');
+      expect(crew.profileUrl, 'https://image.tmdb.org/t/p/w276_and_h350_face/x8B4P0zH4n8k.jpg');
+    });
+  });
+}

--- a/test/services/debrid_service_test.dart
+++ b/test/services/debrid_service_test.dart
@@ -1,0 +1,33 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:playtorrio/models/debrid/debrid_account.dart';
+import 'package:playtorrio/services/debrid/debrid_service.dart';
+
+void main() {
+  group('DebridService', () {
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      DebridService.instance.accounts.value = [];
+      await DebridService.instance.initialize();
+    });
+
+    test('starts with empty accounts', () {
+      expect(DebridService.instance.accounts.value, isEmpty);
+      expect(DebridService.instance.isConfigured(DebridProvider.realDebrid), isFalse);
+    });
+
+    test('removeAccount removes configured provider', () async {
+      DebridService.instance.accounts.value = [
+        const DebridAccount(
+          provider: DebridProvider.realDebrid,
+          apiKey: 'test-token',
+          username: 'tester',
+        ),
+      ];
+
+      expect(DebridService.instance.isConfigured(DebridProvider.realDebrid), isTrue);
+      await DebridService.instance.removeAccount(DebridProvider.realDebrid);
+      expect(DebridService.instance.isConfigured(DebridProvider.realDebrid), isFalse);
+    });
+  });
+}

--- a/test/services/download_service_test.dart
+++ b/test/services/download_service_test.dart
@@ -1,0 +1,64 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:playtorrio/models/download/download_item.dart';
+import 'package:playtorrio/services/download/download_service.dart';
+
+void main() {
+  group('DownloadService', () {
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      DownloadService.downloads.value = [];
+      await DownloadService.initialize();
+    });
+
+    test('addDownload adds items to the list', () {
+      final item = DownloadItem(
+        id: '1',
+        title: 'Arcane',
+        downloadUrl: 'https://example.com/ep1.mp4',
+        createdAt: DateTime.now(),
+      );
+
+      DownloadService.addDownload(item);
+      expect(DownloadService.downloads.value.length, 1);
+      expect(DownloadService.downloads.value.first.title, 'Arcane');
+    });
+
+    test('updateProgress updates progress and status correctly', () {
+      final item = DownloadItem(
+        id: '1',
+        title: 'Arcane',
+        downloadUrl: 'https://example.com/ep1.mp4',
+        createdAt: DateTime.now(),
+      );
+
+      DownloadService.addDownload(item);
+      DownloadService.updateProgress('1', 0.8, 800, 1000, DownloadStatus.downloading);
+
+      final updated = DownloadService.downloads.value.first;
+      expect(updated.progress, 0.8);
+      expect(updated.receivedBytes, 800);
+      expect(updated.totalBytes, 1000);
+      expect(updated.status, DownloadStatus.downloading);
+    });
+
+    test('pause, resume, and remove download', () {
+      final item = DownloadItem(
+        id: '1',
+        title: 'Arcane',
+        downloadUrl: 'https://example.com/ep1.mp4',
+        createdAt: DateTime.now(),
+      );
+
+      DownloadService.addDownload(item);
+      DownloadService.pauseDownload('1');
+      expect(DownloadService.downloads.value.first.status, DownloadStatus.paused);
+
+      DownloadService.resumeDownload('1');
+      expect(DownloadService.downloads.value.first.status, DownloadStatus.downloading);
+
+      DownloadService.removeDownload('1');
+      expect(DownloadService.downloads.value, isEmpty);
+    });
+  });
+}

--- a/test/services/playback_history_service_test.dart
+++ b/test/services/playback_history_service_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:playtorrio/models/playback/playback_history_item.dart';
+import 'package:playtorrio/services/playback/playback_history_service.dart';
+
+void main() {
+  group('PlaybackHistoryService', () {
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      PlaybackHistoryService.history.value = [];
+      await PlaybackHistoryService.initialize();
+    });
+
+    test('saveProgress adds and updates playback timestamps', () {
+      final item = PlaybackHistoryItem(
+        id: 'tt0137523',
+        title: 'Fight Club',
+        position: const Duration(minutes: 45),
+        duration: const Duration(minutes: 139),
+        lastWatched: DateTime.now(),
+      );
+
+      PlaybackHistoryService.saveProgress(item);
+      expect(PlaybackHistoryService.history.value.length, 1);
+      expect(PlaybackHistoryService.getProgress('tt0137523')?.position.inMinutes, 45);
+
+      final updated = item.copyWith(position: const Duration(minutes: 90));
+      PlaybackHistoryService.saveProgress(updated);
+      expect(PlaybackHistoryService.history.value.length, 1);
+      expect(PlaybackHistoryService.getProgress('tt0137523')?.position.inMinutes, 90);
+    });
+
+    test('removeProgress deletes item from history', () {
+      final item = PlaybackHistoryItem(
+        id: 'tt0137523',
+        title: 'Fight Club',
+        position: const Duration(minutes: 45),
+        duration: const Duration(minutes: 139),
+        lastWatched: DateTime.now(),
+      );
+
+      PlaybackHistoryService.saveProgress(item);
+      expect(PlaybackHistoryService.history.value.isNotEmpty, isTrue);
+
+      PlaybackHistoryService.removeProgress('tt0137523');
+      expect(PlaybackHistoryService.history.value, isEmpty);
+    });
+  });
+}

--- a/test/widgets/collection_page_test.dart
+++ b/test/widgets/collection_page_test.dart
@@ -24,6 +24,7 @@ void main() {
       await tester.pumpAndSettle();
       expect(find.text('My List'), findsWidgets);
       expect(find.text('Watchlist'), findsWidgets);
+      expect(find.text('History'), findsWidgets);
       expect(find.text('Downloads'), findsWidgets);
       expect(find.text('Your list is empty'), findsOneWidget);
     });
@@ -48,7 +49,7 @@ void main() {
         createdAt: DateTime.now(),
       ));
 
-      await tester.pumpWidget(wrap(const CollectionPage(initialTabIndex: 2)));
+      await tester.pumpWidget(wrap(const CollectionPage(initialTabIndex: 3)));
       await tester.pumpAndSettle();
       expect(find.text('Cyberpunk Edgerunners'), findsOneWidget);
       expect(find.text('DOWNLOADING • 50%'), findsOneWidget);

--- a/test/widgets/collection_page_test.dart
+++ b/test/widgets/collection_page_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:playtorrio/models/my_list/my_list_item.dart';
+import 'package:playtorrio/models/download/download_item.dart';
+import 'package:playtorrio/services/my_list/my_list_service.dart';
+import 'package:playtorrio/services/download/download_service.dart';
+import 'package:playtorrio/pages/collection/collection_page.dart';
+
+Widget wrap(Widget child) => MaterialApp(home: child);
+
+void main() {
+  group('CollectionPage', () {
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      MyListService.items.value = [];
+      DownloadService.downloads.value = [];
+      await MyListService.initialize();
+      await DownloadService.initialize();
+    });
+
+    testWidgets('shows tabs and empty state for My List', (tester) async {
+      await tester.pumpWidget(wrap(const CollectionPage()));
+      await tester.pumpAndSettle();
+      expect(find.text('My List'), findsWidgets);
+      expect(find.text('Watchlist'), findsWidgets);
+      expect(find.text('Downloads'), findsWidgets);
+      expect(find.text('Your list is empty'), findsOneWidget);
+    });
+
+    testWidgets('shows items in My List when populated', (tester) async {
+      MyListService.add(MyListItem(traktId: 1, title: 'Inception', year: 2010, type: 'movie', addedAt: DateTime(2026)));
+      MyListService.add(MyListItem(traktId: 2, title: 'Interstellar', year: 2014, type: 'movie', addedAt: DateTime(2026)));
+
+      await tester.pumpWidget(wrap(const CollectionPage()));
+      await tester.pumpAndSettle();
+      expect(find.text('Inception'), findsOneWidget);
+      expect(find.text('Interstellar'), findsOneWidget);
+    });
+
+    testWidgets('shows downloads tab content', (tester) async {
+      DownloadService.addDownload(DownloadItem(
+        id: 'dl-1',
+        title: 'Cyberpunk Edgerunners',
+        downloadUrl: 'https://example.com/video.mp4',
+        progress: 0.5,
+        status: DownloadStatus.downloading,
+        createdAt: DateTime.now(),
+      ));
+
+      await tester.pumpWidget(wrap(const CollectionPage(initialTabIndex: 2)));
+      await tester.pumpAndSettle();
+      expect(find.text('Cyberpunk Edgerunners'), findsOneWidget);
+      expect(find.text('DOWNLOADING • 50%'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
Summary

Small navigation fix in AppDock: replaced Navigator.pushReplacement with Navigator.pushAndRemoveUntil to ensure the initial app root route is preserved when switching hubs. This prevents the previous behavior where popping/back could show a black/empty screen because the stack had been replaced.

Files changed

- lib/widgets/common/app_dock.dart — use Navigator.pushAndRemoveUntil keeping route.isFirst

Commit

- 7ad263b — Fix navigation black screen: preserve app root when switching hubs

Branch

- feat/navigation/preserve-root-on-hub-switch (pushed to origin)

Why

- Previously, navigating between hubs used pushReplacement which removed the previous route. If that left the stack empty (or without the expected root), back/pop caused a black screen.
- Using pushAndRemoveUntil(..., (route) => route.isFirst) removes intermediate hub routes but keeps the app root so Back returns to Home reliably.

Testing / How to verify

1. Run the app.
2. From Home, open the dock and tap a hub (e.g., Anime).
3. Press system Back or app Back: the app should return to Home, not a black screen.
4. Open Settings from the dock; Settings should still push as a modal and return normally.

Notes & follow-up

- This is a surgical, minimal fix to resolve the immediate UX bug.
- Recommended follow-up: refactor to a single top-level HubPage (IndexedStack) to manage hub state and navigation more robustly (preserve scroll positions, faster hub switching, simpler back handling).
