### PR TITLE
ci: add SHA-256 checksums to releases + local release helper

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -389,6 +389,21 @@ jobs:
         with:
           merge-multiple: true
 
+      - name: Generate SHA-256 checksums
+        shell: bash
+        run: |
+          # Generate a SHA256SUMS file for every release asset so users can
+          # verify download integrity (mirrors the hashes shown on the release
+          # pages). The checksum file itself is also uploaded.
+          sha256sum *.exe *.zip *.apk *.AppImage *.tar.gz *.dmg *.ipa 2>/dev/null \
+            > SHA256SUMS || true
+          if [ ! -s SHA256SUMS ]; then
+            echo "No release assets found to checksum." >&2
+            exit 1
+          fi
+          echo "Generated SHA256SUMS:"
+          cat SHA256SUMS
+
       - name: Publish Release with Assets
         uses: softprops/action-gh-release@v2
         with:
@@ -404,3 +419,4 @@ jobs:
             *.tar.gz
             *.dmg
             *.ipa
+            SHA256SUMS

--- a/scripts/build_release.ps1
+++ b/scripts/build_release.ps1
@@ -1,0 +1,43 @@
+# ──────────────────────────────────────────────────────────────────────────────
+#  PlayTorrioV3 — Local Release Checksum Helper
+#  Generates a SHA256SUMS file for all release artifacts in a directory,
+#  mirroring what the CI workflow (.github/workflows/build.yml) does before
+#  publishing a GitHub release. Use this to verify local builds before
+#  pushing a release tag.
+#
+#  Usage:
+#    powershell -ExecutionPolicy Bypass -File scripts\build_release.ps1
+#    powershell -ExecutionPolicy Bypass -File scripts\build_release.ps1 -Dir build\releases
+# ──────────────────────────────────────────────────────────────────────────────
+param(
+    [string]$Dir = "build\releases"
+)
+
+$ErrorActionPreference = "Stop"
+
+if (-not (Test-Path $Dir)) {
+    Write-Error "Directory not found: $Dir"
+    exit 1
+}
+
+$extensions = @("*.exe", "*.zip", "*.apk", "*.AppImage", "*.tar.gz", "*.dmg", "*.ipa")
+$files = Get-ChildItem -Path $Dir -File | Where-Object {
+    $name = $_.Name
+    $extensions | Where-Object { $name -like $_ }
+}
+
+if ($files.Count -eq 0) {
+    Write-Error "No release artifacts found in $Dir"
+    exit 1
+}
+
+$lines = foreach ($file in $files) {
+    $hash = (Get-FileHash -Path $file.FullName -Algorithm SHA256).Hash.ToLower()
+    "$hash  $($file.Name)"
+}
+
+$outPath = Join-Path $Dir "SHA256SUMS"
+$lines | Out-File -FilePath $outPath -Encoding ascii
+Write-Host "Generated $outPath with $($files.Count) checksums:"
+$lines | ForEach-Object { Write-Host "  $_" }
+exit 0

--- a/scripts/build_windows.bat
+++ b/scripts/build_windows.bat
@@ -1,0 +1,43 @@
+@echo off
+REM Build Windows release and package full Release folder into a zip for local QA.
+REM Usage: scripts\build_windows.bat [version]
+REM   version  optional version string used in the zip name (default: timestamp).
+REM           Use the same name as CI: PlayTorrio-Windows-x64-Portable.zip
+
+echo Building Windows release (flutter build windows --release)...
+flutter build windows --release
+if %ERRORLEVEL% NEQ 0 (
+  echo Build failed with exit code %ERRORLEVEL%.
+  exit /b %ERRORLEVEL%
+)
+
+set RELEASE_DIR=build\windows\x64\runner\Release
+set OUTPUT_DIR=build\releases
+
+if not exist "%OUTPUT_DIR%" mkdir "%OUTPUT_DIR%"
+
+if "%~1"=="" (
+  set TIMESTAMP=%DATE:~10,4%-%DATE:~4,2%-%DATE:~7,2%_%TIME:~0,2%-%TIME:~3,2%-%TIME:~6,2%
+  set TIMESTAMP=%TIMESTAMP: =0%
+  set ZIP_NAME=playtorrio-windows-x64-%TIMESTAMP%.zip
+) else (
+  set ZIP_NAME=PlayTorrio-Windows-x64-Portable.zip
+)
+
+echo Packaging "%RELEASE_DIR%" -> "%OUTPUT_DIR%\%ZIP_NAME%" ...
+powershell -Command "Compress-Archive -Path '%RELEASE_DIR%\*' -DestinationPath '%OUTPUT_DIR%\%ZIP_NAME%' -Force"
+if %ERRORLEVEL% NEQ 0 (
+  echo Packaging failed.
+  exit /b %ERRORLEVEL%
+)
+
+echo Generating SHA-256 checksum...
+powershell -Command "Get-FileHash '%OUTPUT_DIR%\%ZIP_NAME%' -Algorithm SHA256 | Select-Object -ExpandProperty Hash | Out-File -FilePath '%OUTPUT_DIR%\%ZIP_NAME%.sha256' -Encoding ascii"
+if %ERRORLEVEL% NEQ 0 (
+  echo Checksum generation failed.
+  exit /b %ERRORLEVEL%
+)
+
+echo Done. Created: %OUTPUT_DIR%\%ZIP_NAME%
+echo Checksum: %OUTPUT_DIR%\%ZIP_NAME%.sha256
+exit /b 0


### PR DESCRIPTION
## Summary

Adds SHA-256 checksums to the release pipeline so users can verify download integrity, plus a local helper to generate the same checksums before pushing a release tag.

## Changes

- **.github/workflows/build.yml** — new "Generate SHA-256 checksums" step in the release job. Runs \sha256sum\ over every release asset (\.exe\, \.zip\, \.apk\, \.AppImage\, \.tar.gz\, \.dmg\, \.ipa\), writes a \SHA256SUMS\ file, and uploads it alongside the release assets. This automates the hashes currently shown on release pages.
- **scripts/build_release.ps1** (new) — local PowerShell helper that generates a \SHA256SUMS\ file for release artifacts, mirroring the CI behavior. Useful for verifying local builds before pushing a tag.
- **scripts/build_windows.bat** (new) — builds the Windows release, packages the Release folder into a zip, and writes a \.sha256\ file. Accepts an optional version arg to name the zip \PlayTorrio-Windows-x64-Portable.zip\ (matching CI) instead of a timestamp name.

## Why

The release pages already display \sha256:\ hashes, but the workflow never generated them (they were added manually). Automating them makes releases verifiable and removes a manual step.

## Testing

- \scripts/build_release.ps1\ tested against a local release zip — produced a correct \SHA256SUMS\ (hash matches \Get-FileHash\).
- Workflow YAML validated as syntactically correct.
